### PR TITLE
Adding script hash staking

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
@@ -292,11 +292,12 @@ namespace Stratis.Bitcoin.Features.ColdStaking
         /// <param name="amount">The amount to cold stake.</param>
         /// <param name="feeAmount">The fee to pay for the cold staking setup transaction.</param>
         /// <param name="useSegwitChangeAddress">Use a segwit style change address.</param>
+        /// <param name="payToScript">Indicate script staking (P2SH or P2WSH outputs).</param>
         /// <returns>The <see cref="Transaction"/> for setting up cold staking.</returns>
         /// <exception cref="WalletException">Thrown if any of the rules listed in the remarks section of this method are broken.</exception>
         internal Transaction GetColdStakingSetupTransaction(IWalletTransactionHandler walletTransactionHandler,
             string coldWalletAddress, string hotWalletAddress, string walletName, string walletAccount,
-            string walletPassword, Money amount, Money feeAmount, bool useSegwitChangeAddress = false)
+            string walletPassword, Money amount, Money feeAmount, bool useSegwitChangeAddress = false, bool payToScript = false)
         {
             Guard.NotNull(walletTransactionHandler, nameof(walletTransactionHandler));
             Guard.NotEmpty(coldWalletAddress, nameof(coldWalletAddress));
@@ -334,19 +335,35 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             }
 
             Script destination = null;
+            KeyId hotPubKeyHash = null;
+            KeyId coldPubKeyHash = null;
 
             // Check if this is a segwit address
             if (coldAddress?.Bech32Address == coldWalletAddress || hotAddress?.Bech32Address == hotWalletAddress)
             {
-                KeyId hotPubKeyHash = new BitcoinWitPubKeyAddress(hotWalletAddress, wallet.Network).Hash.AsKeyId();
-                KeyId coldPubKeyHash = new BitcoinWitPubKeyAddress(coldWalletAddress, wallet.Network).Hash.AsKeyId();
+                hotPubKeyHash = new BitcoinWitPubKeyAddress(hotWalletAddress, wallet.Network).Hash.AsKeyId();
+                coldPubKeyHash = new BitcoinWitPubKeyAddress(coldWalletAddress, wallet.Network).Hash.AsKeyId();
                 destination = ColdStakingScriptTemplate.Instance.GenerateScriptPubKey(hotPubKeyHash, coldPubKeyHash);
+
+                if(payToScript)
+                {
+                    HdAddress address = coldAddress ?? hotAddress;
+                    address.RedeemScript = destination;
+                    destination = destination.WitHash.ScriptPubKey;
+                }
             }
             else
             {
-                KeyId hotPubKeyHash = new BitcoinPubKeyAddress(hotWalletAddress, wallet.Network).Hash;
-                KeyId coldPubKeyHash = new BitcoinPubKeyAddress(coldWalletAddress, wallet.Network).Hash;
+                hotPubKeyHash = new BitcoinPubKeyAddress(hotWalletAddress, wallet.Network).Hash;
+                coldPubKeyHash = new BitcoinPubKeyAddress(coldWalletAddress, wallet.Network).Hash;
                 destination = ColdStakingScriptTemplate.Instance.GenerateScriptPubKey(hotPubKeyHash, coldPubKeyHash);
+
+                if (payToScript)
+                {
+                    HdAddress address = coldAddress ?? hotAddress;
+                    address.RedeemScript = destination;
+                    destination = destination.Hash.ScriptPubKey;
+                }
             }
 
             // Only normal accounts should be allowed.
@@ -366,6 +383,28 @@ namespace Stratis.Bitcoin.Features.ColdStaking
                 WalletPassword = walletPassword,
                 Recipients = new List<Recipient>() { new Recipient { Amount = amount, ScriptPubKey = destination } }
             };
+
+            if (payToScript)
+            {
+                // In the case of P2SH and P2WSH, to avoid the possibility of lose of funds
+                // we add an opreturn with the hot and cold key hashes to the setup transaction
+                // this will allow a user to recreate the redeem script of the output in case they lose 
+                // access to one of the keys. 
+                // The special marker will help a wallet that is tracking cold staking accounts to monitor 
+                // the hot and cold keys, if a special marker is found then the keys are in the opreturn are checked 
+                // against the current wallet, if found and validated the wallet will track that ScriptPubKey
+
+                var opreturnKeys = new List<byte>();
+                opreturnKeys.AddRange(hotPubKeyHash.ToBytes());
+                opreturnKeys.AddRange(coldPubKeyHash.ToBytes());
+              
+                context.OpReturnRawData = opreturnKeys.ToArray();
+                //context.OpReturnAmount = Money.Satoshis(1); // mandatory fee must be paid.
+                 
+                // The P2SH and P2WSH hide the cold stake keys in the script hash so the wallet cannot track 
+                // the ouputs based on the derived keys when the trx is subbmited to the network.
+                // So we add the output script manually.
+            }
 
             // Register the cold staking builder extension with the transaction builder.
             context.TransactionBuilder.Extensions.Add(new ColdStakingBuilderExtension(false));
@@ -476,9 +515,21 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             }
 
             // Add keys for signing inputs. This takes time so only add keys for distinct addresses.
-            foreach (HdAddress address in transaction.Inputs.Select(i => mapOutPointToUnspentOutput[i.PrevOut].Address).Distinct())
+            foreach (var item in transaction.Inputs.Select(i => mapOutPointToUnspentOutput[i.PrevOut]).Distinct())
             {
-                context.TransactionBuilder.AddKeys(wallet.GetExtendedPrivateKeyForAddress(walletPassword, address));
+                Script prevscript = item.Transaction.ScriptPubKey;
+
+                if (prevscript.IsScriptType(ScriptType.P2SH) || prevscript.IsScriptType(ScriptType.P2WSH))
+                {
+                    if (item.Address.RedeemScript == null)
+                        throw new WalletException("Missing redeem script");
+
+                    // Provide the redeem script to the builder
+                    var scriptCoin = ScriptCoin.Create(this.network, item.ToOutPoint(), new TxOut(item.Transaction.Amount, prevscript), item.Address.RedeemScript);
+                    context.TransactionBuilder.AddCoins(scriptCoin);
+                }
+
+                context.TransactionBuilder.AddKeys(wallet.GetExtendedPrivateKeyForAddress(walletPassword, item.Address));
             }
 
             // Sign the transaction.
@@ -522,10 +573,101 @@ namespace Stratis.Bitcoin.Features.ColdStaking
             {
                 base.TransactionFoundInternal(hotPubKeyHash.ScriptPubKey, a => a.Index == HotWalletAccountIndex);
                 base.TransactionFoundInternal(coldPubKeyHash.ScriptPubKey, a => a.Index == ColdWalletAccountIndex);
+
+                return;
             }
-            else
+            else if (script.IsScriptType(ScriptType.P2SH) || script.IsScriptType(ScriptType.P2WSH))
             {
-                base.TransactionFoundInternal(script, accountFilter);
+                if (this.scriptToAddressLookup.TryGetValue(script, out HdAddress address))
+                {
+                    if (ColdStakingScriptTemplate.Instance.ExtractScriptPubKeyParameters(address.RedeemScript, out hotPubKeyHash, out coldPubKeyHash))
+                    {
+                        base.TransactionFoundInternal(hotPubKeyHash.ScriptPubKey, a => a.Index == HotWalletAccountIndex);
+                        base.TransactionFoundInternal(coldPubKeyHash.ScriptPubKey, a => a.Index == ColdWalletAccountIndex);
+
+                        return;
+                    }
+                }
+            }
+
+            base.TransactionFoundInternal(script, accountFilter);
+        }
+
+        /// <summary>
+        /// The purpose of this method is to try to identify the P2SH and P2WSH that are coldstake outputs for this wallet
+        /// We look for an opreturn script that is created when seting up a P2SH and P2WSH cold stake trx
+        /// if we find any then try to find the keys and track the script before calling in to the main wallet.  
+        /// </summary>
+        /// <inheritdoc/>
+        public override bool ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true)
+        {
+            foreach (TxOut utxo in transaction.Outputs)
+            {
+                Script script = utxo.ScriptPubKey;
+
+                if (script.IsUnspendable)
+                {
+                    var data = TxNullDataTemplate.Instance.ExtractScriptPubKeyParameters(script);
+                    if (data.Length == 1)
+                    {
+                        if (data[0].Length == 40)
+                        {
+                            HdAddress address = null;
+                            
+                            Span<byte> span = data[0].AsSpan();
+                            var hotPubKey = new KeyId(span.Slice(0, 20).ToArray());
+                            var coldPubKey = new KeyId(span.Slice(20, 20).ToArray());
+
+                            if (this.scriptToAddressLookup.TryGetValue(hotPubKey.ScriptPubKey, out address)
+                                || this.scriptToAddressLookup.TryGetValue(coldPubKey.ScriptPubKey, out address))
+                            {
+                                Script destination = ColdStakingScriptTemplate.Instance.GenerateScriptPubKey(hotPubKey, coldPubKey);
+                                address.RedeemScript = destination;
+
+                                // Find the type of script for the opreturn (P2SH or P2WSH)
+                                foreach (TxOut utxoInner in transaction.Outputs)
+                                {
+                                    if(utxoInner.ScriptPubKey == destination.Hash.ScriptPubKey)
+                                    {
+                                        if (!this.scriptToAddressLookup.TryGetValue(destination.Hash.ScriptPubKey,out HdAddress _))
+                                            this.scriptToAddressLookup[destination.Hash.ScriptPubKey] = address;
+                                        
+                                        break;
+                                    }
+
+                                    if (utxoInner.ScriptPubKey == destination.WitHash.ScriptPubKey)
+                                    {
+                                        if (!this.scriptToAddressLookup.TryGetValue(destination.WitHash.ScriptPubKey, out HdAddress _))
+                                            this.scriptToAddressLookup[destination.WitHash.ScriptPubKey] = address;
+
+                                        break;
+                                    }
+                                }
+
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return base.ProcessTransaction(transaction, blockHeight, block, isPropagated);
+        }
+
+        protected override void AddAddressToIndex(HdAddress address)
+        {
+            base.AddAddressToIndex(address);
+
+            if(address.RedeemScript != null)
+            {
+                // The redeem script has no indication on the script type (P2SH or P2WSH), 
+                // so we track both, add both to the indexer then.
+
+                if (!this.scriptToAddressLookup.TryGetValue(address.RedeemScript.Hash.ScriptPubKey, out HdAddress _))
+                    this.scriptToAddressLookup[address.RedeemScript.Hash.ScriptPubKey] = address;
+
+                if (!this.scriptToAddressLookup.TryGetValue(address.RedeemScript.WitHash.ScriptPubKey, out HdAddress _))
+                    this.scriptToAddressLookup[address.RedeemScript.WitHash.ScriptPubKey] = address;
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Controllers/ColdStakingController.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Controllers/ColdStakingController.cs
@@ -188,7 +188,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
 
                 Transaction transaction = this.ColdStakingManager.GetColdStakingSetupTransaction(
                     this.walletTransactionHandler, request.ColdWalletAddress, request.HotWalletAddress,
-                    request.WalletName, request.WalletAccount, request.WalletPassword, amount, feeAmount, request.SegwitChangeAddress);
+                    request.WalletName, request.WalletAccount, request.WalletPassword, amount, feeAmount, request.SegwitChangeAddress, request.PayToScript);
 
                 var model = new SetupColdStakingResponse
                 {

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Models/ColdStakingModels.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Models/ColdStakingModels.cs
@@ -246,6 +246,11 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Models
         /// </summary>
         public bool SegwitChangeAddress { get; set; }
 
+        /// <summary>
+        /// Use script outputs (P2SH and P2WSH) for cold staking
+        /// </summary>
+        public bool PayToScript { get; set; }
+
         /// <summary>Creates a string containing the properties of this object.</summary>
         /// <returns>A string containing the properties of the object.</returns>
         public override string ToString()

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -873,6 +873,13 @@ namespace Stratis.Bitcoin.Features.Wallet
         public string Address { get; set; }
 
         /// <summary>
+        /// A script that is used for P2SH and P2WSH scenarios (mostly used for staking).
+        /// </summary>
+        [JsonProperty(PropertyName = "redeemScript")]
+        [JsonConverter(typeof(ScriptJsonConverter))]
+        public Script RedeemScript { get; set; }
+
+        /// <summary>
         /// A path to the address as defined in BIP44.
         /// </summary>
         [JsonProperty(PropertyName = "hdPath")]

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -104,7 +104,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         // 2. the list of addresses contained in our wallet for checking whether a transaction is being paid to the wallet.
         // 3. a mapping of all inputs with their corresponding transactions, to facilitate rapid lookup
         private Dictionary<OutPoint, TransactionData> outpointLookup;
-        internal ScriptToAddressLookup scriptToAddressLookup;
+        protected internal ScriptToAddressLookup scriptToAddressLookup;
         private Dictionary<OutPoint, TransactionData> inputLookup;
 
         public WalletManager(
@@ -177,7 +177,9 @@ namespace Stratis.Bitcoin.Features.Wallet
             return new Dictionary<string, ScriptTemplate> {
                 { "P2PK", PayToPubkeyTemplate.Instance },
                 { "P2PKH", PayToPubkeyHashTemplate.Instance },
-                { "P2WPKH", PayToWitPubKeyHashTemplate.Instance }
+                { "P2SH", PayToScriptHashTemplate.Instance },
+                { "P2WPKH", PayToWitPubKeyHashTemplate.Instance },
+                { "P2WSH", PayToWitScriptHashTemplate.Instance }
             };
         }
 
@@ -1010,7 +1012,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public bool ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true)
+        public virtual bool ProcessTransaction(Transaction transaction, int? blockHeight = null, Block block = null, bool isPropagated = true)
         {
             Guard.NotNull(transaction, nameof(transaction));
             uint256 hash = transaction.GetHash();
@@ -1187,7 +1189,6 @@ namespace Stratis.Bitcoin.Features.Wallet
                     this.RemoveTxLookupLocked(transaction);
                 }
             }
-
 
             this.TransactionFoundInternal(script);
         }
@@ -1494,16 +1495,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     {
                         foreach (HdAddress address in account.GetCombinedAddresses())
                         {
-                            // Track the P2PKH of this pubic key
-                            this.scriptToAddressLookup[address.ScriptPubKey] = address;
-
-                            // Track the P2PK of this public key
-                            if (address.Pubkey != null)
-                                this.scriptToAddressLookup[address.Pubkey] = address;
-
-                            // Track the P2WPKH of this pubic key
-                            if (address.Bech32Address != null)
-                                this.scriptToAddressLookup[new BitcoinWitPubKeyAddress(address.Bech32Address, this.network).ScriptPubKey] = address;
+                            this.AddAddressToIndex(address);
 
                             foreach (TransactionData transaction in address.Transactions)
                             {
@@ -1520,6 +1512,20 @@ namespace Stratis.Bitcoin.Features.Wallet
             }
         }
 
+        protected virtual void AddAddressToIndex(HdAddress address)
+        {
+            // Track the P2PKH of this pubic key
+            this.scriptToAddressLookup[address.ScriptPubKey] = address;
+
+            // Track the P2PK of this public key
+            if (address.Pubkey != null)
+                this.scriptToAddressLookup[address.Pubkey] = address;
+
+            // Track the P2WPKH of this pubic key
+            if (address.Bech32Address != null)
+                this.scriptToAddressLookup[new BitcoinWitPubKeyAddress(address.Bech32Address, this.network).ScriptPubKey] = address;
+        }
+
         /// <summary>
         /// Update the keys and transactions we're tracking in memory for faster lookups.
         /// </summary>
@@ -1534,16 +1540,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             {
                 foreach (HdAddress address in addresses)
                 {
-                    // Track the P2PKH of this pubic key
-                    this.scriptToAddressLookup[address.ScriptPubKey] = address;
-
-                    // Track the P2PK of this public key
-                    if (address.Pubkey != null)
-                        this.scriptToAddressLookup[address.Pubkey] = address;
-
-                    // Track the P2WPKH of this pubic key
-                    if (address.Bech32Address != null)
-                        this.scriptToAddressLookup[new BitcoinWitPubKeyAddress(address.Bech32Address, this.network).ScriptPubKey] = address;
+                    this.AddAddressToIndex(address);
                 }
             }
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -425,9 +425,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="context">The context associated with the current transaction being built.</param>
         protected void AddOpReturnOutput(TransactionBuildContext context)
         {
-            if (string.IsNullOrEmpty(context.OpReturnData)) return;
-
-            byte[] bytes = Encoding.UTF8.GetBytes(context.OpReturnData);
+            if (string.IsNullOrEmpty(context.OpReturnData) && context.OpReturnRawData == null) 
+                return;
+            
+            byte[] bytes = context.OpReturnRawData ?? Encoding.UTF8.GetBytes(context.OpReturnData);
+          
             // TODO: Get the template from the network standard scripts instead
             Script opReturnScript = TxNullDataTemplate.Instance.GenerateScriptPubKey(bytes);
             context.TransactionBuilder.Send(opReturnScript, context.OpReturnAmount ?? Money.Zero);
@@ -536,6 +538,11 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// Optional data to be added as an extra OP_RETURN transaction output.
         /// </summary>
         public string OpReturnData { get; set; }
+
+        /// <summary>
+        /// The raw data to be added as an extra OP_RETURN transaction output, this will take precedence over <see cref="OpReturnData"/>.
+        /// </summary>
+        public byte[] OpReturnRawData { get; set; }
 
         /// <summary>
         /// Optional amount to add to the OP_RETURN transaction output.

--- a/src/Stratis.Bitcoin.Networks/Policies/StratisStandardScriptsRegistry.cs
+++ b/src/Stratis.Bitcoin.Networks/Policies/StratisStandardScriptsRegistry.cs
@@ -24,6 +24,8 @@ namespace Stratis.Bitcoin.Networks.Policies
             PayToWitTemplate.Instance
         };
 
+        public List<ScriptTemplate> GetScriptTemplates => this.standardTemplates;
+
         public override void RegisterStandardScriptTemplate(ScriptTemplate scriptTemplate)
         {
             if (!this.standardTemplates.Any(template => (template.Type == scriptTemplate.Type)))


### PR DESCRIPTION
This PR originated in the ObsidianX fork as an attempt to make the ODX network use segwit only consensus.

This will allow to coldstake with a P2WSH (or a P2SH) and provide the cold stake special ScriptPubKey as a redeem script in the inputs WitScript part of the coinstake transaction.

https://github.com/obsidianproject/Obsidian-StratisNode/pull/47
https://github.com/block-core/blockcore/issues/12