### PR TITLE
Move the proof-of-stake time field to the PosTransaction class

### DIFF
--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -2700,7 +2700,8 @@ namespace NBitcoin.Tests
         {
             Transaction outputm = this.stratisMain.CreateTransaction();
             outputm.Version = 1;
-            outputm.Time = Utils.DateTimeToUnixTime(posTimeStamp);
+            if(outputm is PosTransaction posTrx)
+                posTrx.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             outputm.Inputs.Add(new TxIn());
             outputm.Inputs[0].PrevOut = new OutPoint();
             outputm.Inputs[0].ScriptSig = Script.Empty;
@@ -2719,7 +2720,8 @@ namespace NBitcoin.Tests
 
             Transaction inputm = this.stratisMain.CreateTransaction();
             inputm.Version = 1;
-            outputm.Time = Utils.DateTimeToUnixTime(posTimeStamp);
+            if (outputm is PosTransaction posTrx1)
+                posTrx1.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             inputm.Inputs.Add(new TxIn());
             inputm.Inputs[0].PrevOut.Hash = output.GetHash();
             inputm.Inputs[0].PrevOut.N = 0;

--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -2700,7 +2700,7 @@ namespace NBitcoin.Tests
         {
             Transaction outputm = this.stratisMain.CreateTransaction();
             outputm.Version = 1;
-            if(outputm is IPosTrxTime posTrx)
+            if(outputm is IPosTransactionWithTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             outputm.Inputs.Add(new TxIn());
             outputm.Inputs[0].PrevOut = new OutPoint();
@@ -2720,7 +2720,7 @@ namespace NBitcoin.Tests
 
             Transaction inputm = this.stratisMain.CreateTransaction();
             inputm.Version = 1;
-            if (outputm is IPosTrxTime posTrx1)
+            if (outputm is IPosTransactionWithTime posTrx1)
                 posTrx1.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             inputm.Inputs.Add(new TxIn());
             inputm.Inputs[0].PrevOut.Hash = output.GetHash();

--- a/src/NBitcoin.Tests/pos_transaction_tests.cs
+++ b/src/NBitcoin.Tests/pos_transaction_tests.cs
@@ -2700,7 +2700,7 @@ namespace NBitcoin.Tests
         {
             Transaction outputm = this.stratisMain.CreateTransaction();
             outputm.Version = 1;
-            if(outputm is PosTransaction posTrx)
+            if(outputm is IPosTrxTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             outputm.Inputs.Add(new TxIn());
             outputm.Inputs[0].PrevOut = new OutPoint();
@@ -2720,7 +2720,7 @@ namespace NBitcoin.Tests
 
             Transaction inputm = this.stratisMain.CreateTransaction();
             inputm.Version = 1;
-            if (outputm is PosTransaction posTrx1)
+            if (outputm is IPosTrxTime posTrx1)
                 posTrx1.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             inputm.Inputs.Add(new TxIn());
             inputm.Inputs[0].PrevOut.Hash = output.GetHash();

--- a/src/NBitcoin.Tests/script_tests.cs
+++ b/src/NBitcoin.Tests/script_tests.cs
@@ -220,7 +220,8 @@ namespace NBitcoin.Tests
             });
 
             Transaction coldCoinStake = network.CreateTransaction();
-            coldCoinStake.Time = (uint)18276127;
+            if(coldCoinStake is PosTransaction posTrx)
+                posTrx.Time = (uint)18276127;
             coldCoinStake.Inputs.Add(new TxIn(tx.Outputs.AsCoins().First().Outpoint, new Script()));
 
             if (isCoinStake)

--- a/src/NBitcoin.Tests/script_tests.cs
+++ b/src/NBitcoin.Tests/script_tests.cs
@@ -220,7 +220,7 @@ namespace NBitcoin.Tests
             });
 
             Transaction coldCoinStake = network.CreateTransaction();
-            if(coldCoinStake is IPosTrxTime posTrx)
+            if(coldCoinStake is IPosTransactionWithTime posTrx)
                 posTrx.Time = (uint)18276127;
             coldCoinStake.Inputs.Add(new TxIn(tx.Outputs.AsCoins().First().Outpoint, new Script()));
 

--- a/src/NBitcoin.Tests/script_tests.cs
+++ b/src/NBitcoin.Tests/script_tests.cs
@@ -220,7 +220,7 @@ namespace NBitcoin.Tests
             });
 
             Transaction coldCoinStake = network.CreateTransaction();
-            if(coldCoinStake is PosTransaction posTrx)
+            if(coldCoinStake is IPosTrxTime posTrx)
                 posTrx.Time = (uint)18276127;
             coldCoinStake.Inputs.Add(new TxIn(tx.Outputs.AsCoins().First().Outpoint, new Script()));
 

--- a/src/NBitcoin/BitcoinCore/Coins.cs
+++ b/src/NBitcoin/BitcoinCore/Coins.cs
@@ -75,10 +75,9 @@ namespace NBitcoin.BitcoinCore
 
         public Coins(Transaction tx, int height)
         {
-            this.fCoinStake = tx.IsCoinStake;
-
             if (tx is IPosTransactionWithTime posTx)
             {
+                this.fCoinStake = tx.IsCoinStake;
                 this.nTime = posTx.Time;
             }
 
@@ -164,11 +163,10 @@ namespace NBitcoin.BitcoinCore
                 // coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
-                stream.ReadWrite(ref this.fCoinStake);
-
                 // This is an ugly hack that will go away when refactoring coinview
                 if (stream.ConsensusFactory.CreateTransaction() is IPosTransactionWithTime)
                 {
+                    stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);
                 }
             }
@@ -221,11 +219,10 @@ namespace NBitcoin.BitcoinCore
                 //// coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
-                stream.ReadWrite(ref this.fCoinStake);
-
                 // This is an ugly hack that will go away when refactoring coinview
                 if (stream.ConsensusFactory.CreateTransaction() is IPosTransactionWithTime)
                 {
+                    stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);
                 }
 

--- a/src/NBitcoin/BitcoinCore/Coins.cs
+++ b/src/NBitcoin/BitcoinCore/Coins.cs
@@ -75,10 +75,10 @@ namespace NBitcoin.BitcoinCore
 
         public Coins(Transaction tx, int height)
         {
-            if (tx is PosTransaction)
+            if (tx is PosTransaction posTx)
             {
                 this.fCoinStake = tx.IsCoinStake;
-                this.nTime = tx.Time;
+                this.nTime = posTx.Time;
             }
 
             this.CoinBase = tx.IsCoinBase;

--- a/src/NBitcoin/BitcoinCore/Coins.cs
+++ b/src/NBitcoin/BitcoinCore/Coins.cs
@@ -77,8 +77,8 @@ namespace NBitcoin.BitcoinCore
         {
             this.fCoinStake = tx.IsCoinStake;
 
-            if (tx is IPosTrxTime posTx)
-            {   
+            if (tx is IPosTransactionWithTime posTx)
+            {
                 this.nTime = posTx.Time;
             }
 
@@ -166,7 +166,8 @@ namespace NBitcoin.BitcoinCore
 
                 stream.ReadWrite(ref this.fCoinStake);
 
-                if (stream.ConsensusFactory is PosConsensusFactory)
+                // This is an ugly hack that will go away when refactoring coinview
+                if (stream.ConsensusFactory.CreateTransaction() is IPosTransactionWithTime)
                 {
                     stream.ReadWrite(ref this.nTime);
                 }
@@ -222,7 +223,8 @@ namespace NBitcoin.BitcoinCore
 
                 stream.ReadWrite(ref this.fCoinStake);
 
-                if (stream.ConsensusFactory is PosConsensusFactory)
+                // This is an ugly hack that will go away when refactoring coinview
+                if (stream.ConsensusFactory.CreateTransaction() is IPosTransactionWithTime)
                 {
                     stream.ReadWrite(ref this.nTime);
                 }

--- a/src/NBitcoin/BitcoinCore/Coins.cs
+++ b/src/NBitcoin/BitcoinCore/Coins.cs
@@ -75,9 +75,10 @@ namespace NBitcoin.BitcoinCore
 
         public Coins(Transaction tx, int height)
         {
-            if (tx is PosTransaction posTx)
-            {
-                this.fCoinStake = tx.IsCoinStake;
+            this.fCoinStake = tx.IsCoinStake;
+
+            if (tx is IPosTrxTime posTx)
+            {   
                 this.nTime = posTx.Time;
             }
 
@@ -163,9 +164,10 @@ namespace NBitcoin.BitcoinCore
                 // coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
+                stream.ReadWrite(ref this.fCoinStake);
+
                 if (stream.ConsensusFactory is PosConsensusFactory)
                 {
-                    stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);
                 }
             }
@@ -218,9 +220,10 @@ namespace NBitcoin.BitcoinCore
                 //// coinbase height
                 stream.ReadWriteAsVarInt(ref this.nHeight);
 
+                stream.ReadWrite(ref this.fCoinStake);
+
                 if (stream.ConsensusFactory is PosConsensusFactory)
                 {
-                    stream.ReadWrite(ref this.fCoinStake);
                     stream.ReadWrite(ref this.nTime);
                 }
 

--- a/src/NBitcoin/BlockStake.cs
+++ b/src/NBitcoin/BlockStake.cs
@@ -198,7 +198,7 @@ namespace NBitcoin
             return this.IsCoinStake || this.IsCoinBase;
         }
 
-        public virtual void ReadWrite(BitcoinStream stream)
+        public override void ReadWrite(BitcoinStream stream)
         {
             bool witSupported = (((uint)stream.TransactionOptions & (uint)TransactionOptions.Witness) != 0) &&
                                 stream.ProtocolVersion >= ProtocolVersion.WITNESS_VERSION;

--- a/src/NBitcoin/BlockStake.cs
+++ b/src/NBitcoin/BlockStake.cs
@@ -155,13 +155,17 @@ namespace NBitcoin
     }
 
     /// <summary>
+    ///  Represnts a transaction with a time field.
+    /// </summary>
+    public interface IPosTrxTime
+    {
+        uint Time { get; set; }
+    }
+
+    /// <summary>
     /// A Proof Of Stake transaction.
     /// </summary>
-    /// <remarks>
-    /// TODO: later we can move the POS timestamp field in this class.
-    /// serialization can be refactored to have a common array that will be serialized and each inheritance can add to the array)
-    /// </remarks>
-    public class PosTransaction : Transaction
+    public class PosTransaction : Transaction 
     {
         public bool IsColdCoinStake { get; set; }
 

--- a/src/NBitcoin/BlockStake.cs
+++ b/src/NBitcoin/BlockStake.cs
@@ -155,9 +155,12 @@ namespace NBitcoin
     }
 
     /// <summary>
-    ///  Represnts a transaction with a time field.
+    ///  Represents a transaction with a time field, such trx are used by POS networks however 
+    ///  the time field is not really needed anymore for POS consensus so in order to allow a new PoSv4 protocol
+    ///  network we make this field encapsolated by an interface, removing the time field will make POS
+    ///  transactions have the same serialization format as Bitcoin.
     /// </summary>
-    public interface IPosTrxTime
+    public interface IPosTransactionWithTime
     {
         uint Time { get; set; }
     }
@@ -165,7 +168,7 @@ namespace NBitcoin
     /// <summary>
     /// A Proof Of Stake transaction.
     /// </summary>
-    public class PosTransaction : Transaction 
+    public class PosTransaction : Transaction , IPosTransactionWithTime
     {
         public bool IsColdCoinStake { get; set; }
 

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -334,7 +334,8 @@ namespace NBitcoin
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = (uint)version;
-            txNew.Time = unixTime;
+            if (txNew is PosTransaction posTx)
+                posTx.Time = unixTime;
             txNew.AddInput(new TxIn()
             {
                 ScriptSig = new Script(

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -334,7 +334,7 @@ namespace NBitcoin
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = (uint)version;
-            if (txNew is PosTransaction posTx)
+            if (txNew is IPosTrxTime posTx)
                 posTx.Time = unixTime;
             txNew.AddInput(new TxIn()
             {

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -334,7 +334,7 @@ namespace NBitcoin
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = (uint)version;
-            if (txNew is IPosTrxTime posTx)
+            if (txNew is IPosTransactionWithTime posTx)
                 posTx.Time = unixTime;
             txNew.AddInput(new TxIn()
             {

--- a/src/NBitcoin/Transaction.cs
+++ b/src/NBitcoin/Transaction.cs
@@ -1153,7 +1153,7 @@ namespace NBitcoin
             }
         }
 
-        private uint nVersion = 1;
+        protected uint nVersion = 1;
 
         public uint Version
         {
@@ -1167,23 +1167,10 @@ namespace NBitcoin
             }
         }
 
-        private uint nTime = Utils.DateTimeToUnixTime(DateTime.UtcNow);
 
-        public uint Time
-        {
-            get
-            {
-                return this.nTime;
-            }
-            set
-            {
-                this.nTime = value;
-            }
-        }
-
-        private TxInList vin;
-        private TxOutList vout;
-        private LockTime nLockTime;
+        protected TxInList vin;
+        protected TxOutList vout;
+        protected LockTime nLockTime;
 
         public Transaction()
         {
@@ -1227,7 +1214,7 @@ namespace NBitcoin
         }
 
         //Since it is impossible to serialize a transaction with 0 input without problems during deserialization with wit activated, we fit a flag in the version to workaround it
-        private const uint NoDummyInput = (1 << 27);
+        protected const uint NoDummyInput = (1 << 27);
 
         #region IBitcoinSerializable Members
 
@@ -1240,10 +1227,6 @@ namespace NBitcoin
             if (!stream.Serializing)
             {
                 stream.ReadWrite(ref this.nVersion);
-
-                // the POS time stamp
-                if (this is PosTransaction)
-                    stream.ReadWrite(ref this.nTime);
 
                 /* Try to read the vin. In case the dummy is there, this will be read as an empty vector. */
                 stream.ReadWrite<TxInList, TxIn>(ref this.vin);
@@ -1293,10 +1276,6 @@ namespace NBitcoin
             {
                 uint version = (witSupported && (this.vin.Count == 0 && this.vout.Count > 0)) ? this.nVersion | NoDummyInput : this.nVersion;
                 stream.ReadWrite(ref version);
-
-                // the POS time stamp
-                if (this is PosTransaction)
-                    stream.ReadWrite(ref this.nTime);
 
                 if (witSupported)
                 {

--- a/src/NBitcoin/TransactionBuilder.cs
+++ b/src/NBitcoin/TransactionBuilder.cs
@@ -1162,7 +1162,8 @@ namespace NBitcoin
                 ctx.Transaction.LockTime = this._LockTime.Value;
 
             if (this._TimeStamp != null)
-                ctx.Transaction.Time = this._TimeStamp.Value;
+                if (ctx.Transaction is PosTransaction posTx)
+                    posTx.Time = this._TimeStamp.Value;
 
             foreach (BuilderGroup group in this._BuilderGroups)
             {

--- a/src/NBitcoin/TransactionBuilder.cs
+++ b/src/NBitcoin/TransactionBuilder.cs
@@ -1162,7 +1162,7 @@ namespace NBitcoin
                 ctx.Transaction.LockTime = this._LockTime.Value;
 
             if (this._TimeStamp != null)
-                if (ctx.Transaction is IPosTrxTime posTx)
+                if (ctx.Transaction is IPosTransactionWithTime posTx)
                     posTx.Time = this._TimeStamp.Value;
 
             foreach (BuilderGroup group in this._BuilderGroups)

--- a/src/NBitcoin/TransactionBuilder.cs
+++ b/src/NBitcoin/TransactionBuilder.cs
@@ -1162,7 +1162,7 @@ namespace NBitcoin
                 ctx.Transaction.LockTime = this._LockTime.Value;
 
             if (this._TimeStamp != null)
-                if (ctx.Transaction is PosTransaction posTx)
+                if (ctx.Transaction is IPosTrxTime posTx)
                     posTx.Time = this._TimeStamp.Value;
 
             foreach (BuilderGroup group in this._BuilderGroups)

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinviewTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinviewTests.cs
@@ -157,7 +157,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
         private UnspentOutputs CreateOutputs(int height, int outputsCount = 20)
         {
             var tx = new Transaction();
-            tx.Time = RandomUtils.GetUInt32();
+            tx.LockTime = RandomUtils.GetUInt32(); // add randmoness
 
             for (int i = 0; i < outputsCount; i++)
             {

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -105,7 +105,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         private static Transaction CreateCoinStakeTransaction(Network network, Key key, int height, uint256 prevout)
         {
             var coinStake = network.CreateTransaction();
-            coinStake.Time = (uint)18276127;
+            if(coinStake is PosTransaction posTrx)
+                posTrx.Time = (uint)18276127;
             coinStake.AddInput(new TxIn(new OutPoint(prevout, 1)));
             coinStake.AddOutput(new TxOut(0, new Script()));
             coinStake.AddOutput(new TxOut(network.GetReward(height), key.ScriptPubKey));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -106,7 +106,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         private static Transaction CreateCoinStakeTransaction(Network network, Key key, int height, uint256 prevout)
         {
             var coinStake = network.CreateTransaction();
-            if(coinStake is PosTransaction posTrx)
+            if(coinStake is IPosTrxTime posTrx)
                 posTrx.Time = (uint)18276127;
             coinStake.AddInput(new TxIn(new OutPoint(prevout, 1)));
             coinStake.AddOutput(new TxOut(0, new Script()));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -106,7 +106,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         private static Transaction CreateCoinStakeTransaction(Network network, Key key, int height, uint256 prevout)
         {
             var coinStake = network.CreateTransaction();
-            if(coinStake is IPosTrxTime posTrx)
+            if(coinStake is IPosTransactionWithTime posTrx)
                 posTrx.Time = (uint)18276127;
             coinStake.AddInput(new TxIn(new OutPoint(prevout, 1)));
             coinStake.AddOutput(new TxOut(0, new Script()));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/CalculateStakeRuleTest.cs
@@ -27,6 +27,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
                 BlockToValidate = block,
                 ChainedHeaderToValidate = this.ChainIndexer.GetHeader(4)
             };
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = 18276127;
 
             var target = new Target(0x1f111115);
             this.ruleContext.ValidationContext.BlockToValidate.Header.Bits = target;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
@@ -169,7 +169,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // we need to ensure that the transaction used for the coinstake's
             // input occurs well before the block time (as the coinstake time
             // is set to the block time)
-            ((PosTransacion)prevTransaction).Time = blockTime - 100;
+            if(prevTransaction is PosTransaction posTrx)
+                posTrx.Time = blockTime - 100;
 
             // Coins sent to miner 2.
             prevTransaction.Outputs.Add(new TxOut(Money.COIN * 5_000_000, scriptPubKey2));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
@@ -169,7 +169,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // we need to ensure that the transaction used for the coinstake's
             // input occurs well before the block time (as the coinstake time
             // is set to the block time)
-            if(prevTransaction is IPosTrxTime posTrx)
+            if(prevTransaction is IPosTransactionWithTime posTrx)
                 posTrx.Time = blockTime - 100;
 
             // Coins sent to miner 2.

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
@@ -169,7 +169,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // we need to ensure that the transaction used for the coinstake's
             // input occurs well before the block time (as the coinstake time
             // is set to the block time)
-            if(prevTransaction is PosTransaction posTrx)
+            if(prevTransaction is IPosTrxTime posTrx)
                 posTrx.Time = blockTime - 100;
 
             // Coins sent to miner 2.

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
@@ -169,7 +169,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // we need to ensure that the transaction used for the coinstake's
             // input occurs well before the block time (as the coinstake time
             // is set to the block time)
-            prevTransaction.Time = blockTime - 100;
+            ((PosTransacion)prevTransaction).Time = blockTime - 100;
 
             // Coins sent to miner 2.
             prevTransaction.Outputs.Add(new TxOut(Money.COIN * 5_000_000, scriptPubKey2));
@@ -208,8 +208,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             block.Header.Time = blockTime;
             block.Header.Bits = block.Header.GetWorkRequired(this.network, this.ChainIndexer.Tip);
             block.SetPrivatePropertyValue("BlockSize", 1L);
-            block.Transactions[0].Time = block.Header.Time;
-            block.Transactions[1].Time = block.Header.Time;
             block.UpdateMerkleRoot();
             Assert.True(BlockStake.IsProofOfStake(block));
             // Add a signature to the block.

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinstakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinstakeRuleTest.cs
@@ -102,7 +102,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
             this.ruleContext.ValidationContext.BlockToValidate.Header.Time = (uint)1483747200;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Time = (uint)1483747201;
+            ((PosTransaction)this.ruleContext.ValidationContext.BlockToValidate.Transactions[1]).Time = (uint)1483747201;
 
             Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.BlockToValidate));
 
@@ -119,7 +119,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
             this.ruleContext.ValidationContext.BlockToValidate.Header.Time = (uint)1483747200;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = (uint)1483747201;
+            ((PosTransaction)this.ruleContext.ValidationContext.BlockToValidate.Transactions[0]).Time = (uint)1483747201;
 
             Assert.True(BlockStake.IsProofOfWork(this.ruleContext.ValidationContext.BlockToValidate));
 
@@ -146,8 +146,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
 
             this.ruleContext.ValidationContext.BlockToValidate.Header.Time = (uint)1483747200;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = (uint)1483747200;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Time = (uint)1483747200;
+            ((PosTransaction)this.ruleContext.ValidationContext.BlockToValidate.Transactions[0]).Time = (uint)1483747200;
+            ((PosTransaction)this.ruleContext.ValidationContext.BlockToValidate.Transactions[1]).Time = (uint)1483747200;
 
             Assert.True(BlockStake.IsProofOfStake(this.ruleContext.ValidationContext.BlockToValidate));
 
@@ -161,7 +161,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             transaction.Outputs.Add(new TxOut(Money.Zero, (IDestination)null));
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(transaction);
             this.ruleContext.ValidationContext.BlockToValidate.Header.Time = (uint)1483747200;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = (uint)1483747200;
+            ((PosTransaction)this.ruleContext.ValidationContext.BlockToValidate.Transactions[0]).Time = (uint)1483747200;
 
             Assert.True(BlockStake.IsProofOfWork(this.ruleContext.ValidationContext.BlockToValidate));
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosColdStakingRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosColdStakingRuleTest.cs
@@ -83,8 +83,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             // Finalize the block and add it to the chain.
             block.Header.HashPrevBlock = this.ChainIndexer.Tip.HashBlock;
             block.Header.Time = (uint)1483747200;
-            block.Transactions[0].Time = (uint)1483747200;
-            block.Transactions[1].Time = (uint)1483747200;
             block.UpdateMerkleRoot();
 
             Assert.True(BlockStake.IsProofOfStake(block));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosTimeMaskRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosTimeMaskRuleTest.cs
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate = this.network.Consensus.ConsensusFactory.CreateBlock();
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(this.network.CreateTransaction());
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(this.network.CreateTransaction());
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = (uint)(StratisBugFixPosFutureDriftRule.DriftingBugFixTimestamp);
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = (uint)(StratisBugFixPosFutureDriftRule.DriftingBugFixTimestamp);
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = this.ChainIndexer.GetHeader(3);
 
             ConsensusErrorException exception = await Assert.ThrowsAsync<ConsensusErrorException>(() => rule.RunAsync(this.ruleContext));
@@ -59,7 +59,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate = this.network.Consensus.ConsensusFactory.CreateBlock();
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(this.network.CreateTransaction());
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(this.network.CreateTransaction());
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = (uint)(StratisBugFixPosFutureDriftRule.DriftingBugFixTimestamp);
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = (uint)(StratisBugFixPosFutureDriftRule.DriftingBugFixTimestamp);
 
             // create a stake trx
             this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Inputs.Add(new TxIn(new OutPoint(uint256.One, 0)));
@@ -69,8 +69,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = this.ChainIndexer.GetHeader(3);
 
             this.network.Consensus.LastPOWBlock = 12500;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Time = this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time + MaxFutureDriftAfterHardFork + 1;
-            this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header.Time = this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time + MaxFutureDriftAfterHardFork;
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = this.ruleContext.ValidationContext.BlockToValidate.Header.Time + MaxFutureDriftAfterHardFork + 1;
+            this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header.Time = this.ruleContext.ValidationContext.BlockToValidate.Header.Time + MaxFutureDriftAfterHardFork;
 
             rule.FutureDriftRule = new StratisBugFixPosFutureDriftRule();
 
@@ -89,7 +89,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             this.ruleContext.ValidationContext.BlockToValidate = this.network.Consensus.ConsensusFactory.CreateBlock();
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(this.network.CreateTransaction());
             this.ruleContext.ValidationContext.BlockToValidate.Transactions.Add(this.network.CreateTransaction());
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = (uint)(StratisBugFixPosFutureDriftRule.DriftingBugFixTimestamp);
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = (uint)(StratisBugFixPosFutureDriftRule.DriftingBugFixTimestamp);
 
             // create a stake trx
             this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Inputs.Add(new TxIn(new OutPoint(uint256.One, 0)));
@@ -98,8 +98,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = this.ChainIndexer.GetHeader(3);
             this.network.Consensus.LastPOWBlock = 12500;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Time = this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time + MaxFutureDriftAfterHardFork;
-            this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header.Time = this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time + MaxFutureDriftAfterHardFork;
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = this.ruleContext.ValidationContext.BlockToValidate.Header.Time + MaxFutureDriftAfterHardFork;
+            this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header.Time = this.ruleContext.ValidationContext.BlockToValidate.Header.Time + MaxFutureDriftAfterHardFork;
 
             rule.FutureDriftRule = new StratisBugFixPosFutureDriftRule();
 
@@ -124,8 +124,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             // time same as previous block.
             uint previousBlockHeaderTime = this.ruleContext.ValidationContext.ChainedHeaderToValidate.Previous.Header.Time;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = previousBlockHeaderTime;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Time = previousBlockHeaderTime;
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = previousBlockHeaderTime;
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = previousBlockHeaderTime;
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header.Time = previousBlockHeaderTime;
 
             ConsensusErrorException exception = Assert.Throws<ConsensusErrorException>(() => rule.Run(this.ruleContext));
@@ -149,8 +149,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
 
             // time after previous block.
             uint previousBlockHeaderTime = this.ruleContext.ValidationContext.ChainedHeaderToValidate.Previous.Header.Time;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[0].Time = previousBlockHeaderTime + 62;
-            this.ruleContext.ValidationContext.BlockToValidate.Transactions[1].Time = previousBlockHeaderTime + 64;
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = previousBlockHeaderTime + 62;
+            this.ruleContext.ValidationContext.BlockToValidate.Header.Time = previousBlockHeaderTime + 64;
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header.Time = previousBlockHeaderTime + 64;
 
             rule.FutureDriftRule = new StratisBugFixPosFutureDriftRule();

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/TransactionLocktimeActivationRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/TransactionLocktimeActivationRuleTest.cs
@@ -103,7 +103,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
         private static Transaction CreateCoinStakeTransaction(Network network, Key key, int height, uint256 prevout)
         {
             var coinStake = network.CreateTransaction();
-            coinStake.Time = (uint)18276127;
+           // coinStake.Time = (uint)18276127;
             coinStake.AddInput(new TxIn(new OutPoint(prevout, 1)));
             coinStake.AddOutput(new TxOut(0, new Script()));
             coinStake.AddOutput(new TxOut(network.GetReward(height), key.ScriptPubKey));

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ConsensusRuleUnitTestBase.cs
@@ -312,7 +312,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             {
                 var hash = new uint256(RandomUtils.GetBytes(32));
                 hashes.Add(hash);
-                this.posBlock.Transactions.Add(new Transaction { Time = (uint)i });
+                this.posBlock.Transactions.Add(new PosTransaction { Time = (uint)i });
             }
 
             this.posBlock.UpdateMerkleRoot();

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
@@ -78,7 +78,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), null);
@@ -107,7 +106,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.Transactions[1].Inputs[0].PrevOut.N = 2;
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), null);
@@ -134,7 +132,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), null);
@@ -194,7 +191,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
                 .Returns(new FetchCoinsResponse(new[] { new UnspentOutputs(10, new Transaction()) }, posBlock.GetHash()));
 
             // Change coinstake time to differ from header time but divisible by 16.
-            ((ProvenBlockHeader)this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header).Coinstake.Time = 16;
+            ((ProvenBlockHeader)this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header).Time = 16;
 
             // When we run the validation rule, we should hit coinstake stake time violation error.
             Action ruleValidation = () => this.consensusRules.RegisterRule<ProvenHeaderCoinstakeRule>().Run(this.ruleContext);
@@ -204,7 +201,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
 
             // Change coinstake time to be the same as header time but not divisible by 16.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header.Time = 50;
-            ((ProvenBlockHeader)this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header).Coinstake.Time = 50;
+            ((ProvenBlockHeader)this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header).Time = 50;
 
             // When we run the validation rule, we should hit coinstake stake time violation error.
             ruleValidation.Should().Throw<ConsensusErrorException>()
@@ -225,7 +222,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
@@ -266,7 +262,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
@@ -311,7 +306,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
@@ -357,7 +351,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
@@ -409,7 +402,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Corrupt merkle proof.
             provenBlockHeader.SetPrivateVariableValue("merkleProof", new PartialMerkleTree(new[] { new uint256(1234) }, new[] { false }));
@@ -468,7 +460,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.UpdateMerkleRoot();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
+            //provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key.
             provenBlockHeader.Coinstake.Outputs[1].ScriptPubKey = new Script("03cdac179a3391d96cf4957fa0255e4aa8055a993e92df7146e740117885b184ea OP_CHECKSIG");
@@ -535,7 +527,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key
             provenBlockHeader.Coinstake.Outputs[1].ScriptPubKey = privateKey.PubKey.ScriptPubKey;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
@@ -78,7 +78,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.Transactions[1].Inputs[0].PrevOut.N = 2;
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -228,7 +228,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -270,7 +270,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -316,7 +316,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -363,7 +363,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -416,7 +416,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Corrupt merkle proof.
@@ -476,7 +476,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.UpdateMerkleRoot();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key.
@@ -544,7 +544,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
@@ -78,6 +78,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), null);
@@ -106,16 +108,18 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.Transactions[1].Inputs[0].PrevOut.N = 2;
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), null);
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.SetPrivatePropertyValue("Height", this.provenHeadersActivationHeight + 10);
 
             // Ensure that coinview returns a UTXO with valid outputs.
-            var utxoOneTransaction = new Transaction();
+            var utxoOneTransaction = this.network.CreateTransaction();
             utxoOneTransaction.AddOutput(new TxOut());
             var utxoOne = new UnspentOutputs(10, utxoOneTransaction);
-            var utxoTwo = new UnspentOutputs(11, new Transaction());
+            var utxoTwo = new UnspentOutputs(11, this.network.CreateTransaction());
 
             this.coinView
                 .Setup(m => m.FetchCoins(It.IsAny<uint256[]>(), It.IsAny<CancellationToken>()))
@@ -132,6 +136,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), null);
@@ -163,7 +169,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup coinstake transaction.
             this.coinView
                 .Setup(m => m.FetchCoins(It.IsAny<uint256[]>(), It.IsAny<CancellationToken>()))
-                .Returns(new FetchCoinsResponse(new[] { new UnspentOutputs(10, new Transaction()) }, posBlock.GetHash()));
+                .Returns(new FetchCoinsResponse(new[] { new UnspentOutputs(10, this.network.CreateTransaction()) }, posBlock.GetHash()));
 
             // Change coinstake outputs to make it invalid.
             ((ProvenBlockHeader)this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header).Coinstake.Outputs.RemoveAt(0);
@@ -188,7 +194,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup coinstake transaction.
             this.coinView
                 .Setup(m => m.FetchCoins(It.IsAny<uint256[]>(), It.IsAny<CancellationToken>()))
-                .Returns(new FetchCoinsResponse(new[] { new UnspentOutputs(10, new Transaction()) }, posBlock.GetHash()));
+                .Returns(new FetchCoinsResponse(new[] { new UnspentOutputs(10, this.network.CreateTransaction()) }, posBlock.GetHash()));
 
             // Change coinstake time to differ from header time but divisible by 16.
             ((ProvenBlockHeader)this.ruleContext.ValidationContext.ChainedHeaderToValidate.Header).Time = 16;
@@ -222,13 +228,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.SetPrivatePropertyValue("Height", this.provenHeadersActivationHeight + 2);
 
             // Ensure that coinview returns a UTXO with valid outputs.
-            var utxoOneTransaction = new Transaction();
+            var utxoOneTransaction = this.network.CreateTransaction();
             utxoOneTransaction.AddOutput(new TxOut());
             var utxoOne = new UnspentOutputs(10, utxoOneTransaction);
 
@@ -262,13 +270,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.SetPrivatePropertyValue("Height", this.provenHeadersActivationHeight + 2);
 
             // Ensure that coinview returns UTXO with valid outputs.
-            var utxoOneTransaction = new Transaction();
+            var utxoOneTransaction = this.network.CreateTransaction();
             utxoOneTransaction.AddOutput(new TxOut());
             var utxoOne = new UnspentOutputs((uint)this.provenHeadersActivationHeight + 10, utxoOneTransaction);
 
@@ -306,13 +316,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.SetPrivatePropertyValue("Height", this.provenHeadersActivationHeight + 2);
 
             // Ensure that coinview returns a UTXO with valid outputs.
-            var utxoOneTransaction = new Transaction();
+            var utxoOneTransaction = this.network.CreateTransaction();
             utxoOneTransaction.AddOutput(new TxOut());
             var utxoOne = new UnspentOutputs((uint)this.provenHeadersActivationHeight + 10, utxoOneTransaction);
 
@@ -351,13 +363,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
             this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(provenBlockHeader, provenBlockHeader.GetHash(), previousChainedHeader);
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.SetPrivatePropertyValue("Height", this.provenHeadersActivationHeight + 2);
 
             // Ensure that coinview returns a UTXO with valid outputs.
-            var utxoOneTransaction = new Transaction();
+            var utxoOneTransaction = this.network.CreateTransaction();
             utxoOneTransaction.AddOutput(new TxOut());
             var utxoOne = new UnspentOutputs((uint)this.provenHeadersActivationHeight + 10, utxoOneTransaction);
 
@@ -402,6 +416,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Corrupt merkle proof.
             provenBlockHeader.SetPrivateVariableValue("merkleProof", new PartialMerkleTree(new[] { new uint256(1234) }, new[] { false }));
@@ -411,7 +427,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             this.ruleContext.ValidationContext.ChainedHeaderToValidate.SetPrivatePropertyValue("Height", this.provenHeadersActivationHeight + 2);
 
             // Ensure that coinview returns a UTXO with valid outputs.
-            var utxoOneTransaction = new Transaction();
+            var utxoOneTransaction = this.network.CreateTransaction();
             utxoOneTransaction.AddOutput(new TxOut());
             var utxoOne = new UnspentOutputs(10, utxoOneTransaction);
 
@@ -460,7 +476,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.UpdateMerkleRoot();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            //provenBlockHeader.Coinstake.Time = provenBlockHeader.Time;
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key.
             provenBlockHeader.Coinstake.Outputs[1].ScriptPubKey = new Script("03cdac179a3391d96cf4957fa0255e4aa8055a993e92df7146e740117885b184ea OP_CHECKSIG");
@@ -472,7 +489,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup coinstake transaction with a valid stake age.
             uint unspentOutputsHeight = (uint)this.provenHeadersActivationHeight + 10;
 
-            var unspentOutputs = new UnspentOutputs(unspentOutputsHeight, new Transaction())
+            var unspentOutputs = new UnspentOutputs(unspentOutputsHeight, this.network.CreateTransaction())
             {
                 Outputs = new[] { new TxOut(new Money(100), privateKey.PubKey) }
             };
@@ -527,6 +544,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
+            if (provenBlockHeader.Coinstake is PosTransaction posTrx)
+                posTrx.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key
             provenBlockHeader.Coinstake.Outputs[1].ScriptPubKey = privateKey.PubKey.ScriptPubKey;
@@ -537,7 +556,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
 
             // Setup coinstake transaction with a valid stake age.
             uint unspentOutputsHeight = (uint)this.provenHeadersActivationHeight + 10;
-            var unspentOutputs = new UnspentOutputs(unspentOutputsHeight, new Transaction())
+            var unspentOutputs = new UnspentOutputs(unspentOutputsHeight, this.network.CreateTransaction())
             {
                 Outputs = new[] { new TxOut(new Money(100), privateKey.PubKey) }
             };

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/ProvenHeaderRules/ProvenBlockHeaderCoinstakeRuleTest.cs
@@ -78,7 +78,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.Transactions[1].Inputs[0].PrevOut.N = 2;
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -136,7 +136,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             // Setup proven header.
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -228,7 +228,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -270,7 +270,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -316,7 +316,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build();
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -363,7 +363,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Setup chained header and move it to the height higher than proven header activation height.
@@ -416,7 +416,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             PosBlock posBlock = new PosBlockBuilder(this.network).Build();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Corrupt merkle proof.
@@ -476,7 +476,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
             posBlock.UpdateMerkleRoot();
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key.
@@ -544,7 +544,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.ProvenHeaderRules
 
             ProvenBlockHeader provenBlockHeader = new ProvenBlockHeaderBuilder(posBlock, this.network).Build(prevProvenBlockHeader);
             provenBlockHeader.HashPrevBlock = prevProvenBlockHeader.GetHash();
-            if (provenBlockHeader.Coinstake is IPosTrxTime posTrx)
+            if (provenBlockHeader.Coinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = provenBlockHeader.Time;
 
             // Set invalid coinstake script pub key

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
@@ -776,7 +776,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var transactionTimestamp = DateTime.Now;
             var posTimeStamp = transactionTimestamp.AddSeconds(-1);
             var transaction = this.Network.CreateTransaction();
-            transaction.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
+            if (transaction is PosTransaction posTrx)
+                posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
 
@@ -791,7 +792,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var transactionTimestamp = DateTime.Now;
             var posTimeStamp = transactionTimestamp;
             var transaction = CreateStubCoinStakeTransaction();
-            transaction.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
+            if (transaction is PosTransaction posTrx)
+                posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
             var outpoint = new OutPoint(transaction, 1);
@@ -808,7 +810,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp;
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            transaction.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
+            if (transaction is PosTransaction posTrx)
+                posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
             var outpoint = new OutPoint(transaction, 1);
@@ -824,7 +827,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp;
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            transaction.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
+            if (transaction is PosTransaction posTrx)
+                posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
             var outpoint = new OutPoint(transaction, 1);
@@ -840,7 +844,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp.AddSeconds(1);
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            transaction.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
+            if (transaction is PosTransaction posTrx)
+                posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
             var outpoint = new OutPoint(transaction, 1);
@@ -1021,7 +1026,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             var outPoint = new OutPoint(transaction, 1);
             var headerbits = Target.Difficulty1.ToCompact();
-            var transactionTime = stakableHeader.Block.Transactions[0].Time;
+            var transactionTime = ((PosTransaction)stakableHeader.Block.Transactions[0]).Time;
 
             this.stakeValidator.CheckKernel(new PosRuleContext(), header, headerbits, transactionTime, outPoint);
         }
@@ -1387,7 +1392,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             Transaction outputm = this.Network.CreateTransaction();
             outputm.Version = 1;
-            outputm.Time = Utils.DateTimeToUnixTime(posTimeStamp);
+            if (outputm is PosTransaction posTrx)
+                posTrx.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             outputm.Inputs.Add(new TxIn());
             outputm.Inputs[0].PrevOut = new OutPoint();
             outputm.Inputs[0].ScriptSig = Script.Empty;
@@ -1413,7 +1419,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             Transaction inputm = this.Network.CreateTransaction();
             inputm.Version = 1;
-            outputm.Time = Utils.DateTimeToUnixTime(posTimeStamp);
+            if (outputm is PosTransaction posTrx1)
+                posTrx1.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             inputm.Inputs.Add(new TxIn());
             inputm.Inputs[0].PrevOut.Hash = output.GetHash();
             inputm.Inputs[0].PrevOut.N = 0;

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
@@ -779,7 +779,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var transactionTimestamp = DateTime.Now;
             var posTimeStamp = transactionTimestamp.AddSeconds(-1);
             var transaction = this.Network.CreateTransaction();
-            if (transaction is IPosTrxTime posTrx)
+            if (transaction is IPosTransactionWithTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -795,7 +795,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var transactionTimestamp = DateTime.Now;
             var posTimeStamp = transactionTimestamp;
             var transaction = CreateStubCoinStakeTransaction();
-            if (transaction is IPosTrxTime posTrx)
+            if (transaction is IPosTransactionWithTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -813,7 +813,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp;
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            if (transaction is IPosTrxTime posTrx)
+            if (transaction is IPosTransactionWithTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -830,7 +830,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp;
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            if (transaction is IPosTrxTime posTrx)
+            if (transaction is IPosTransactionWithTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -847,7 +847,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp.AddSeconds(1);
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            if (transaction is IPosTrxTime posTrx)
+            if (transaction is IPosTransactionWithTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -1395,7 +1395,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             Transaction outputm = this.Network.CreateTransaction();
             outputm.Version = 1;
-            if (outputm is IPosTrxTime posTrx)
+            if (outputm is IPosTransactionWithTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             outputm.Inputs.Add(new TxIn());
             outputm.Inputs[0].PrevOut = new OutPoint();
@@ -1422,7 +1422,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             Transaction inputm = this.Network.CreateTransaction();
             inputm.Version = 1;
-            if (outputm is IPosTrxTime posTrx1)
+            if (outputm is IPosTransactionWithTime posTrx1)
                 posTrx1.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             inputm.Inputs.Add(new TxIn());
             inputm.Inputs[0].PrevOut.Hash = output.GetHash();

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
@@ -766,6 +766,9 @@ namespace Stratis.Bitcoin.Tests.Consensus
                 UnspentOutputSet = new UnspentOutputSet()
             };
             context.UnspentOutputSet.SetCoins(new UnspentOutputs[] { unspentoutputs });
+           
+            context.ValidationContext = new ValidationContext() { ChainedHeaderToValidate = chainedHeader.Previous };
+            chainedHeader.Previous.Header.Time = ((PosTransaction)input1).Time;
 
             this.stakeValidator.CheckProofOfStake(context, chainedHeader, blockStake, input1, headerbits);
         }

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/StakeValidatorTests.cs
@@ -779,7 +779,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var transactionTimestamp = DateTime.Now;
             var posTimeStamp = transactionTimestamp.AddSeconds(-1);
             var transaction = this.Network.CreateTransaction();
-            if (transaction is PosTransaction posTrx)
+            if (transaction is IPosTrxTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -795,7 +795,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var transactionTimestamp = DateTime.Now;
             var posTimeStamp = transactionTimestamp;
             var transaction = CreateStubCoinStakeTransaction();
-            if (transaction is PosTransaction posTrx)
+            if (transaction is IPosTrxTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -813,7 +813,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp;
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            if (transaction is PosTransaction posTrx)
+            if (transaction is IPosTrxTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -830,7 +830,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp;
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            if (transaction is PosTransaction posTrx)
+            if (transaction is IPosTrxTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -847,7 +847,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
             var posTimeStamp = transactionTimestamp.AddSeconds(1);
 
             var transaction = CreateStubCoinStakeTransaction(5000 * Money.COIN);
-            if (transaction is PosTransaction posTrx)
+            if (transaction is IPosTrxTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(transactionTimestamp);
             uint transactionTime = Utils.DateTimeToUnixTime(posTimeStamp);
             UnspentOutputs stakingCoins = new UnspentOutputs(15, transaction);
@@ -1395,7 +1395,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         {
             Transaction outputm = this.Network.CreateTransaction();
             outputm.Version = 1;
-            if (outputm is PosTransaction posTrx)
+            if (outputm is IPosTrxTime posTrx)
                 posTrx.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             outputm.Inputs.Add(new TxIn());
             outputm.Inputs[0].PrevOut = new OutPoint();
@@ -1422,7 +1422,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             Transaction inputm = this.Network.CreateTransaction();
             inputm.Version = 1;
-            if (outputm is PosTransaction posTrx1)
+            if (outputm is IPosTrxTime posTrx1)
                 posTrx1.Time = Utils.DateTimeToUnixTime(posTimeStamp);
             inputm.Inputs.Add(new TxIn());
             inputm.Inputs[0].PrevOut.Hash = output.GetHash();

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
@@ -79,18 +79,27 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 }
             }
 
+            // TODO: while time is not used anymore 
+            // we keep this check to avoid a network split
+
             // Check transactions.
             foreach (Transaction transaction in block.Transactions)
             {
-                // Check transaction timestamp.
-                if (block.Header.Time < transaction.Time)
+                // With the new changes this check is actually not needed amnymore.
+                // The trx time has no meaning for the network,its a legacy field from
+                // the days where coin age was used for POS protocol.
+                if (transaction is PosTransaction posTrx)
                 {
-                    this.Logger.LogDebug("Block contains transaction with timestamp {0}, which is greater than block's timestamp {1}.", transaction.Time, block.Header.Time);
-                    this.Logger.LogTrace("(-)[TX_TIME_MISMATCH]");
-                    ConsensusErrors.BlockTimeBeforeTrx.Throw();
+                    // Check transaction timestamp.
+                    if (block.Header.Time < posTrx.Time)
+                    {
+                        this.Logger.LogDebug("Block contains transaction with timestamp {0}, which is greater than block's timestamp {1}.", posTrx.Time, block.Header.Time);
+                        this.Logger.LogTrace("(-)[TX_TIME_MISMATCH]");
+                        ConsensusErrors.BlockTimeBeforeTrx.Throw();
+                    }
                 }
             }
-
+            
             return Task.CompletedTask;
         }
     }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 // With the new changes this check is actually not needed amnymore.
                 // The trx time has no meaning for the network,its a legacy field from
                 // the days where coin age was used for POS protocol.
-                if (transaction is IPosTrxTime posTrx)
+                if (transaction is IPosTransactionWithTime posTrx)
                 {
                     // Check transaction timestamp.
                     if (block.Header.Time < posTrx.Time)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinstakeRule.cs
@@ -88,7 +88,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
                 // With the new changes this check is actually not needed amnymore.
                 // The trx time has no meaning for the network,its a legacy field from
                 // the days where coin age was used for POS protocol.
-                if (transaction is PosTransaction posTrx)
+                if (transaction is IPosTrxTime posTrx)
                 {
                     // Check transaction timestamp.
                     if (block.Header.Time < posTrx.Time)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
@@ -114,9 +114,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         /// <inheritdoc />
         protected override void CheckInputValidity(Transaction transaction, UnspentOutputs coins)
         {
-            // Transaction timestamp earlier than input transaction - main.cpp, CTransaction::ConnectInputs
-            if (coins.Time > transaction.Time)
-                ConsensusErrors.BadTransactionEarlyTimestamp.Throw();
+            // TODO: Keep this check to avoid a network split
+            if (transaction is PosTransaction posTrx)
+            {
+                // Transaction timestamp earlier than input transaction - main.cpp, CTransaction::ConnectInputs
+                if (coins.Time > posTrx.Time)
+                    ConsensusErrors.BadTransactionEarlyTimestamp.Throw();
+            }
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         protected override void CheckInputValidity(Transaction transaction, UnspentOutputs coins)
         {
             // TODO: Keep this check to avoid a network split
-            if (transaction is IPosTrxTime posTrx)
+            if (transaction is IPosTransactionWithTime posTrx)
             {
                 // Transaction timestamp earlier than input transaction - main.cpp, CTransaction::ConnectInputs
                 if (coins.Time > posTrx.Time)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/PosCoinviewRule.cs
@@ -115,7 +115,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         protected override void CheckInputValidity(Transaction transaction, UnspentOutputs coins)
         {
             // TODO: Keep this check to avoid a network split
-            if (transaction is PosTransaction posTrx)
+            if (transaction is IPosTrxTime posTrx)
             {
                 // Transaction timestamp earlier than input transaction - main.cpp, CTransaction::ConnectInputs
                 if (coins.Time > posTrx.Time)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
@@ -177,10 +177,16 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.ProvenHeaderRules
         /// </exception>
         private void CheckHeaderAndCoinstakeTimes(ProvenBlockHeader header)
         {
-            uint coinstakeTime = header.Coinstake.Time;
-            uint headerTime = header.Time;
+            if (header.Coinstake is PosTransaction posTrx)
+            {
+                if (header.Time != posTrx.Time)
+                {
+                    this.Logger.LogTrace("(-)[BAD_TIME]");
+                    ConsensusErrors.StakeTimeViolation.Throw();
+                }
+            }
 
-            if ((headerTime != coinstakeTime) || ((coinstakeTime & PosConsensusOptions.StakeTimestampMask) != 0))
+            if ((header.Time & PosConsensusOptions.StakeTimestampMask) != 0)
             {
                 this.Logger.LogTrace("(-)[BAD_TIME]");
                 ConsensusErrors.StakeTimeViolation.Throw();
@@ -282,7 +288,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.ProvenHeaderRules
         private void CheckStakeKernelHash(PosRuleContext context, UnspentOutputs stakingCoins, ProvenBlockHeader header, ChainedHeader chainedHeader)
         {
             OutPoint prevOut = this.GetPreviousOut(header);
-            uint transactionTime = header.Coinstake.Time;
+            uint transactionTime = header.Time;
             uint headerBits = chainedHeader.Header.Bits.ToCompact();
 
             uint256 previousStakeModifier = this.GetPreviousStakeModifier(chainedHeader);

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
@@ -177,7 +177,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.ProvenHeaderRules
         /// </exception>
         private void CheckHeaderAndCoinstakeTimes(ProvenBlockHeader header)
         {
-            if (header.Coinstake is PosTransaction posTrx)
+            if (header.Coinstake is IPosTrxTime posTrx)
             {
                 if (header.Time != posTrx.Time)
                 {

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/ProvenHeaderRules/ProvenHeaderCoinstakeRule.cs
@@ -177,7 +177,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.ProvenHeaderRules
         /// </exception>
         private void CheckHeaderAndCoinstakeTimes(ProvenBlockHeader header)
         {
-            if (header.Coinstake is IPosTrxTime posTrx)
+            if (header.Coinstake is IPosTransactionWithTime posTrx)
             {
                 if (header.Time != posTrx.Time)
                 {

--- a/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeValidator.cs
@@ -223,7 +223,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                 ConsensusErrors.InvalidStakeDepth.Throw();
             }
 
-            if (!this.CheckStakeKernelHash(context, headerBits, prevBlockStake.StakeModifierV2, prevUtxo, txIn.PrevOut, transaction.Time))
+            if (!this.CheckStakeKernelHash(context, headerBits, prevBlockStake.StakeModifierV2, prevUtxo, txIn.PrevOut, context.ValidationContext.ChainedHeaderToValidate.Header.Time))
             {
                 this.logger.LogTrace("(-)[INVALID_STAKE_HASH_TARGET]");
                 ConsensusErrors.StakeHashInvalidTarget.Throw();

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -454,13 +454,16 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // TODO: Move this into its own small rule that only PoS networks use.
             if (this.network.Consensus.IsProofOfStake)
             {
-                long adjustedTime = this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
-                PosFutureDriftRule futureDriftRule = this.consensusRules.GetRule<PosFutureDriftRule>();
-
-                // nTime has different purpose from nLockTime but can be used in similar attacks.
-                if (tx.Time > adjustedTime + futureDriftRule.GetFutureDrift(adjustedTime))
+                if (tx is PosTransaction posTrx)
                 {
-                    context.State.Fail(MempoolErrors.TimeTooNew).Throw();
+                    long adjustedTime = this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
+                    PosFutureDriftRule futureDriftRule = this.consensusRules.GetRule<PosFutureDriftRule>();
+
+                    // nTime has different purpose from nLockTime but can be used in similar attacks.
+                    if (posTrx.Time > adjustedTime + futureDriftRule.GetFutureDrift(adjustedTime))
+                    {
+                        context.State.Fail(MempoolErrors.TimeTooNew).Throw();
+                    }
                 }
             }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -454,7 +454,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // TODO: Move this into its own small rule that only PoS networks use.
             if (this.network.Consensus.IsProofOfStake)
             {
-                if (tx is IPosTrxTime posTrx)
+                if (tx is IPosTransactionWithTime posTrx)
                 {
                     long adjustedTime = this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
                     PosFutureDriftRule futureDriftRule = this.consensusRules.GetRule<PosFutureDriftRule>();

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolValidator.cs
@@ -454,7 +454,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             // TODO: Move this into its own small rule that only PoS networks use.
             if (this.network.Consensus.IsProofOfStake)
             {
-                if (tx is PosTransaction posTrx)
+                if (tx is IPosTrxTime posTrx)
                 {
                     long adjustedTime = this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
                     PosFutureDriftRule futureDriftRule = this.consensusRules.GetRule<PosFutureDriftRule>();

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -87,7 +87,8 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 var datetime = new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc);
                 this.dateTimeProvider.Setup(d => d.GetAdjustedTimeAsUnixTimestamp()).Returns(datetime.ToUnixTimestamp());
                 Transaction transaction = CreateTransaction(this.stratisTest, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
-                transaction.Time = Utils.DateTimeToUnixTime(datetime);
+                if(transaction is PosTransaction posTrx)
+                    posTrx.Time = Utils.DateTimeToUnixTime(datetime);
                 var txFee = new Money(1000);
 
                 SetupTxMempool(chainIndexer, this.stratisTest.Consensus.Options as PosConsensusOptions, txFee, transaction);
@@ -106,7 +107,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.Equal(2, blockTemplate.Block.Transactions.Count);
 
                 Transaction resultingTransaction = blockTemplate.Block.Transactions[0];
-                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
+                //Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.NotEmpty(resultingTransaction.Inputs);
                 Assert.NotEmpty(resultingTransaction.Outputs);
                 Assert.True(resultingTransaction.IsCoinBase);
@@ -234,7 +235,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.NotEmpty(result.Block.Transactions);
 
                 Transaction resultingTransaction = result.Block.Transactions[0];
-                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
+               // Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.True(resultingTransaction.IsCoinBase);
                 Assert.False(resultingTransaction.IsCoinStake);
                 Assert.Equal(Money.Zero, resultingTransaction.TotalOut);
@@ -292,7 +293,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
 
                 Transaction transaction = CreateTransaction(this.stratisTest, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
 
-                this.dateTimeProvider.Setup(s => s.GetAdjustedTimeAsUnixTimestamp()).Returns(transaction.Time);
+                this.dateTimeProvider.Setup(s => s.GetAdjustedTimeAsUnixTimestamp()).Returns(chainIndexer.Tip.Header.Time);
 
                 var txFee = new Money(1000);
                 SetupTxMempool(chainIndexer, newOptions, txFee, transaction);

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -87,7 +87,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 var datetime = new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc);
                 this.dateTimeProvider.Setup(d => d.GetAdjustedTimeAsUnixTimestamp()).Returns(datetime.ToUnixTimestamp());
                 Transaction transaction = CreateTransaction(this.stratisTest, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
-                if(transaction is IPosTrxTime posTrx)
+                if(transaction is IPosTransactionWithTime posTrx)
                     posTrx.Time = Utils.DateTimeToUnixTime(datetime);
                 var txFee = new Money(1000);
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosBlockAssemblerTest.cs
@@ -87,7 +87,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 var datetime = new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc);
                 this.dateTimeProvider.Setup(d => d.GetAdjustedTimeAsUnixTimestamp()).Returns(datetime.ToUnixTimestamp());
                 Transaction transaction = CreateTransaction(this.stratisTest, this.key, 5, new Money(400 * 1000 * 1000), new Key(), new uint256(124124));
-                if(transaction is PosTransaction posTrx)
+                if(transaction is IPosTrxTime posTrx)
                     posTrx.Time = Utils.DateTimeToUnixTime(datetime);
                 var txFee = new Money(1000);
 

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PowBlockAssemblerTest.cs
@@ -82,7 +82,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.Equal(2, blockTemplate.Block.Transactions.Count);
 
                 Transaction resultingTransaction = blockTemplate.Block.Transactions[0];
-                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
+               // Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.NotEmpty(resultingTransaction.Inputs);
                 Assert.NotEmpty(resultingTransaction.Outputs);
                 Assert.True(resultingTransaction.IsCoinBase);
@@ -182,7 +182,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
                 Assert.NotEmpty(result.Block.Transactions);
 
                 Transaction resultingTransaction = result.Block.Transactions[0];
-                Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
+                //Assert.Equal((uint)new DateTime(2017, 1, 7, 0, 0, 1, DateTimeKind.Utc).ToUnixTimestamp(), resultingTransaction.Time);
                 Assert.True(resultingTransaction.IsCoinBase);
                 Assert.False(resultingTransaction.IsCoinStake);
                 Assert.Equal(Money.Zero, resultingTransaction.TotalOut);

--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -166,7 +166,8 @@ namespace Stratis.Bitcoin.Features.Miner
         protected virtual void CreateCoinbase()
         {
             this.coinbase = this.Network.CreateTransaction();
-            this.coinbase.Time = (uint)this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
+            if(this.coinbase is PosTransaction posTrx)
+                posTrx.Time =  (uint)this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
             this.coinbase.AddInput(TxIn.CreateCoinbase(this.ChainTip.Height + 1));
             this.coinbase.AddOutput(new TxOut(Money.Zero, this.scriptPubKey));
 

--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -166,7 +166,7 @@ namespace Stratis.Bitcoin.Features.Miner
         protected virtual void CreateCoinbase()
         {
             this.coinbase = this.Network.CreateTransaction();
-            if(this.coinbase is IPosTrxTime posTrx)
+            if(this.coinbase is IPosTransactionWithTime posTrx)
                 posTrx.Time =  (uint)this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
             this.coinbase.AddInput(TxIn.CreateCoinbase(this.ChainTip.Height + 1));
             this.coinbase.AddOutput(new TxOut(Money.Zero, this.scriptPubKey));

--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -166,7 +166,7 @@ namespace Stratis.Bitcoin.Features.Miner
         protected virtual void CreateCoinbase()
         {
             this.coinbase = this.Network.CreateTransaction();
-            if(this.coinbase is PosTransaction posTrx)
+            if(this.coinbase is IPosTrxTime posTrx)
                 posTrx.Time =  (uint)this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
             this.coinbase.AddInput(TxIn.CreateCoinbase(this.ChainTip.Height + 1));
             this.coinbase.AddOutput(new TxOut(Money.Zero, this.scriptPubKey));

--- a/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
@@ -79,13 +79,16 @@ namespace Stratis.Bitcoin.Features.Miner
             if (this.futureDriftRule == null)
                 this.futureDriftRule = this.ConsensusManager.ConsensusRules.GetRule<PosFutureDriftRule>();
 
-            long adjustedTime = this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
+            if (entry.Transaction is PosTransaction posTrx)
+            {
+                long adjustedTime = this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
 
-            if (entry.Transaction.Time > adjustedTime + this.futureDriftRule.GetFutureDrift(adjustedTime))
-                return false;
+                if (posTrx.Time > adjustedTime + this.futureDriftRule.GetFutureDrift(adjustedTime))
+                    return false;
 
-            if (entry.Transaction.Time > this.block.Transactions[0].Time)
-                return false;
+                if (posTrx.Time > ((PosTransaction)this.block.Transactions[0]).Time)
+                    return false;
+            }
 
             return base.TestPackage(entry, packageSize, packageSigOpsCost);
         }

--- a/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
@@ -79,7 +79,7 @@ namespace Stratis.Bitcoin.Features.Miner
             if (this.futureDriftRule == null)
                 this.futureDriftRule = this.ConsensusManager.ConsensusRules.GetRule<PosFutureDriftRule>();
 
-            if (entry.Transaction is PosTransaction posTrx)
+            if (entry.Transaction is IPosTrxTime posTrx)
             {
                 long adjustedTime = this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
 

--- a/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosBlockDefinition.cs
@@ -79,7 +79,7 @@ namespace Stratis.Bitcoin.Features.Miner
             if (this.futureDriftRule == null)
                 this.futureDriftRule = this.ConsensusManager.ConsensusRules.GetRule<PosFutureDriftRule>();
 
-            if (entry.Transaction is IPosTrxTime posTrx)
+            if (entry.Transaction is IPosTransactionWithTime posTrx)
             {
                 long adjustedTime = this.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
 

--- a/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
@@ -85,11 +85,14 @@ namespace Stratis.Bitcoin.Features.Miner
             // We can include txes with timestamp greater than header's timestamp and those txes are invalid to have in block.
             // However this is needed in order to avoid recreation of block template on every attempt to find kernel.
             // When kernel is found txes with timestamp greater than header's timestamp are removed.
-            if (entry.Transaction.Time > latestValidTime)
+            if (entry.Transaction is PosTransaction posTrx)
             {
-                this.logger.LogDebug("Transaction '{0}' has timestamp of {1} but latest valid tx time that can be mined is {2}.", entry.TransactionHash, entry.Transaction.Time, latestValidTime);
-                this.logger.LogTrace("(-)[TOO_EARLY_TO_MINE_TX]:false");
-                return false;
+                if (posTrx.Time > latestValidTime)
+                {
+                    this.logger.LogDebug("Transaction '{0}' has timestamp of {1} but latest valid tx time that can be mined is {2}.", entry.TransactionHash, posTrx.Time, latestValidTime);
+                    this.logger.LogTrace("(-)[TOO_EARLY_TO_MINE_TX]:false");
+                    return false;
+                }
             }
 
             return base.TestPackage(entry, packageSize, packageSigOpsCost);

--- a/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.Miner
             // We can include txes with timestamp greater than header's timestamp and those txes are invalid to have in block.
             // However this is needed in order to avoid recreation of block template on every attempt to find kernel.
             // When kernel is found txes with timestamp greater than header's timestamp are removed.
-            if (entry.Transaction is IPosTrxTime posTrx)
+            if (entry.Transaction is IPosTransactionWithTime posTrx)
             {
                 if (posTrx.Time > latestValidTime)
                 {

--- a/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PosPowBlockDefinition.cs
@@ -85,7 +85,7 @@ namespace Stratis.Bitcoin.Features.Miner
             // We can include txes with timestamp greater than header's timestamp and those txes are invalid to have in block.
             // However this is needed in order to avoid recreation of block template on every attempt to find kernel.
             // When kernel is found txes with timestamp greater than header's timestamp are removed.
-            if (entry.Transaction is PosTransaction posTrx)
+            if (entry.Transaction is IPosTrxTime posTrx)
             {
                 if (posTrx.Time > latestValidTime)
                 {

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/CoinstakeContext.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/CoinstakeContext.cs
@@ -12,5 +12,8 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
         
         /// <summary>If the function succeeds, this is filled with private key for signing the coinstake kernel.</summary>
         public Key Key { get; set; }
+
+        /// <summary>The time slot that stake was found.</summary>
+        public uint StakeTimeSlot { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -570,7 +570,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                 {
                     // Make sure coinstake would meet timestamp protocol as it would be the same as the block timestamp.
                     block.Header.Time = coinstakeContext.StakeTimeSlot;
-                    if (block.Transactions[0] is PosTransaction posTrx)
+                    if (block.Transactions[0] is IPosTrxTime posTrx)
                     {
                         posTrx.Time = coinstakeContext.StakeTimeSlot;
                     }
@@ -687,16 +687,16 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             for (int i = blockTemplate.Block.Transactions.Count - 1; i >= 1; i--)
             {
                 // We have not yet updated the header timestamp, so we use the coinstake timestamp directly here.
-                if (blockTemplate.Block.Transactions[i] is PosTransaction posTrx)
+                if (blockTemplate.Block.Transactions[i] is IPosTrxTime posTrx)
                 {
                     if (posTrx.Time <= coinstakeContext.StakeTimeSlot)
                         continue;
 
                     // Update the total fees, with the to-be-removed transaction taken into account.
-                    fees -= blockTemplate.FeeDetails[posTrx.GetHash()].Satoshi;
+                    fees -= blockTemplate.FeeDetails[blockTemplate.Block.Transactions[i].GetHash()].Satoshi;
 
                     this.logger.LogDebug("Removing transaction with timestamp {0} as it is greater than coinstake transaction timestamp {1}. New fee amount {2}.", posTrx.Time, coinstakeContext.StakeTimeSlot, fees);
-                    blockTemplate.Block.Transactions.Remove(posTrx);
+                    blockTemplate.Block.Transactions.Remove(blockTemplate.Block.Transactions[i]);
                 }
             }
 
@@ -720,7 +720,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             int eventuallyStakableUtxosCount = utxoStakeDescriptions.Count;
             Transaction coinstakeTx = this.PrepareCoinStakeTransactions(chainTip.Height, coinstakeContext, coinstakeOutputValue, eventuallyStakableUtxosCount, ourWeight);
 
-            if(coinstakeTx is PosTransaction posTrxn)
+            if(coinstakeTx is IPosTrxTime posTrxn)
             {
                 posTrxn.Time = coinstakeContext.StakeTimeSlot;
             }

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -570,10 +570,9 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                 {
                     // Make sure coinstake would meet timestamp protocol as it would be the same as the block timestamp.
                     block.Header.Time = coinstakeContext.StakeTimeSlot;
-                    if (coinstakeContext.CoinstakeTx is PosTransaction posTrx)
+                    if (block.Transactions[0] is PosTransaction posTrx)
                     {
                         posTrx.Time = coinstakeContext.StakeTimeSlot;
-                        ((PosTransaction)block.Transactions[0]).Time = coinstakeContext.StakeTimeSlot;
                     }
 
                     block.Transactions.Insert(1, coinstakeContext.CoinstakeTx);
@@ -720,6 +719,11 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
 
             int eventuallyStakableUtxosCount = utxoStakeDescriptions.Count;
             Transaction coinstakeTx = this.PrepareCoinStakeTransactions(chainTip.Height, coinstakeContext, coinstakeOutputValue, eventuallyStakableUtxosCount, ourWeight);
+
+            if(coinstakeTx is PosTransaction posTrxn)
+            {
+                posTrxn.Time = coinstakeContext.StakeTimeSlot;
+            }
 
             // Sign.
             if (!this.SignTransactionInput(coinstakeInput, coinstakeTx))

--- a/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/Staking/PosMinting.cs
@@ -570,7 +570,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
                 {
                     // Make sure coinstake would meet timestamp protocol as it would be the same as the block timestamp.
                     block.Header.Time = coinstakeContext.StakeTimeSlot;
-                    if (block.Transactions[0] is IPosTrxTime posTrx)
+                    if (block.Transactions[0] is IPosTransactionWithTime posTrx)
                     {
                         posTrx.Time = coinstakeContext.StakeTimeSlot;
                     }
@@ -687,7 +687,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             for (int i = blockTemplate.Block.Transactions.Count - 1; i >= 1; i--)
             {
                 // We have not yet updated the header timestamp, so we use the coinstake timestamp directly here.
-                if (blockTemplate.Block.Transactions[i] is IPosTrxTime posTrx)
+                if (blockTemplate.Block.Transactions[i] is IPosTransactionWithTime posTrx)
                 {
                     if (posTrx.Time <= coinstakeContext.StakeTimeSlot)
                         continue;
@@ -720,7 +720,7 @@ namespace Stratis.Bitcoin.Features.Miner.Staking
             int eventuallyStakableUtxosCount = utxoStakeDescriptions.Count;
             Transaction coinstakeTx = this.PrepareCoinStakeTransactions(chainTip.Height, coinstakeContext, coinstakeOutputValue, eventuallyStakableUtxosCount, ourWeight);
 
-            if(coinstakeTx is IPosTrxTime posTrxn)
+            if(coinstakeTx is IPosTransactionWithTime posTrxn)
             {
                 posTrxn.Time = coinstakeContext.StakeTimeSlot;
             }

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -253,7 +253,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = 1;
-            txNew.Time = nTime;
+            ((PosTransaction)txNew).Time = nTime;
             txNew.AddInput(new TxIn()
             {
                 ScriptSig = new Script(Op.GetPushOp(0), new Op()

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -253,7 +253,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = 1;
-            ((PosTransaction)txNew).Time = nTime;
+            //((PosTransaction)txNew).Time = nTime;
             txNew.AddInput(new TxIn()
             {
                 ScriptSig = new Script(Op.GetPushOp(0), new Op()

--- a/src/Stratis.Bitcoin.Features.SignalR/Events/TransactionReceivedClientEvent.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Events/TransactionReceivedClientEvent.cs
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.Features.SignalR.Events
                 this.TxHash = transactionReceived.ReceivedTransaction.GetHash().ToString();
                 this.IsCoinbase = transactionReceived.ReceivedTransaction.IsCoinBase;
                 this.IsCoinstake = transactionReceived.ReceivedTransaction.IsCoinStake;
-                this.Time = transactionReceived.ReceivedTransaction.Time;
+               // this.Time = transactionReceived.ReceivedTransaction.Time;
                 return;
             }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1132,7 +1132,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                     BlockHash = block?.GetHash(),
                     BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == transactionHash),
                     Id = transactionHash,
-                    CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? transaction.Time),
+                    CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? this.dateTimeProvider.GetTime()),
                     Index = index,
                     ScriptPubKey = script,
                     Hex = this.walletSettings.SaveTransactionHex ? transaction.ToHex() : null,
@@ -1247,7 +1247,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 {
                     TransactionId = transactionHash,
                     Payments = payments,
-                    CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? transaction.Time),
+                    CreationTime = DateTimeOffset.FromUnixTimeSeconds(block?.Header.Time ?? this.dateTimeProvider.GetTime()),
                     BlockHeight = blockHeight,
                     BlockIndex = block?.Transactions.FindIndex(t => t.GetHash() == transactionHash),
                     Hex = this.walletSettings.SaveTransactionHex ? transaction.ToHex() : null,

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -363,7 +363,11 @@ namespace Stratis.Bitcoin.Features.Wallet
             string hex;
             if (transactionFromStore != null)
             {
-                transactionTime = Utils.UnixTimeToDateTime(chainedHeaderBlock.ChainedHeader.Header.Time);
+                if (transactionFromStore is PosTransaction posTrx)
+                    transactionTime = Utils.UnixTimeToDateTime(posTrx.Time);
+                else
+                    transactionTime = Utils.UnixTimeToDateTime(chainedHeaderBlock.ChainedHeader.Header.Time);
+
                 isGenerated = transactionFromStore.IsCoinBase || transactionFromStore.IsCoinStake;
                 hex = transactionFromStore.ToHex();
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -363,7 +363,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             string hex;
             if (transactionFromStore != null)
             {
-                if (transactionFromStore is PosTransaction posTrx)
+                if (transactionFromStore is IPosTrxTime posTrx)
                     transactionTime = Utils.UnixTimeToDateTime(posTrx.Time);
                 else
                     transactionTime = Utils.UnixTimeToDateTime(chainedHeaderBlock.ChainedHeader.Header.Time);

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -363,7 +363,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             string hex;
             if (transactionFromStore != null)
             {
-                transactionTime = Utils.UnixTimeToDateTime(transactionFromStore.Time);
+                transactionTime = Utils.UnixTimeToDateTime(chainedHeaderBlock.ChainedHeader.Header.Time);
                 isGenerated = transactionFromStore.IsCoinBase || transactionFromStore.IsCoinStake;
                 hex = transactionFromStore.ToHex();
 

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -363,7 +363,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             string hex;
             if (transactionFromStore != null)
             {
-                if (transactionFromStore is IPosTrxTime posTrx)
+                if (transactionFromStore is IPosTransactionWithTime posTrx)
                     transactionTime = Utils.UnixTimeToDateTime(posTrx.Time);
                 else
                     transactionTime = Utils.UnixTimeToDateTime(chainedHeaderBlock.ChainedHeader.Header.Time);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
@@ -70,7 +70,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
                 // Create a valid coinbase transaction.
                 var coinbase = this.coreNode.FullNode.Network.CreateTransaction();
-                coinbase.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
+                if (coinbase is PosTransaction posTx)
+                    posTx.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
                 coinbase.AddInput(TxIn.CreateCoinbase(chainTip.Height + 1));
                 coinbase.AddOutput(new TxOut(this.coreNode.FullNode.Network.Consensus.ProofOfWorkReward, this.coreNode.MinerSecret.GetAddress()));
                 block.AddTransaction(coinbase);
@@ -113,7 +114,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         public static Block InvalidDuplicateCoinbase(CoreNode coreNode, Block block)
         {
             var badTxNoInputs = coreNode.FullNode.Network.CreateTransaction();
-            badTxNoInputs.Time = (uint)coreNode.FullNode.NodeService<IDateTimeProvider>().GetAdjustedTimeAsUnixTimestamp();
+            if (badTxNoInputs is PosTransaction posTx)
+                posTx.Time = (uint)coreNode.FullNode.NodeService<IDateTimeProvider>().GetAdjustedTimeAsUnixTimestamp();
             badTxNoInputs.AddInput(new TxIn());
             badTxNoInputs.AddOutput(new TxOut(Money.Coins(1), coreNode.MinerSecret.GetAddress()));
 

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
                 // Create a valid coinbase transaction.
                 var coinbase = this.coreNode.FullNode.Network.CreateTransaction();
-                if (coinbase is PosTransaction posTx)
+                if (coinbase is IPosTrxTime posTx)
                     posTx.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
                 coinbase.AddInput(TxIn.CreateCoinbase(chainTip.Height + 1));
                 coinbase.AddOutput(new TxOut(this.coreNode.FullNode.Network.Consensus.ProofOfWorkReward, this.coreNode.MinerSecret.GetAddress()));
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         public static Block InvalidDuplicateCoinbase(CoreNode coreNode, Block block)
         {
             var badTxNoInputs = coreNode.FullNode.Network.CreateTransaction();
-            if (badTxNoInputs is PosTransaction posTx)
+            if (badTxNoInputs is IPosTrxTime posTx)
                 posTx.Time = (uint)coreNode.FullNode.NodeService<IDateTimeProvider>().GetAdjustedTimeAsUnixTimestamp();
             badTxNoInputs.AddInput(new TxIn());
             badTxNoInputs.AddOutput(new TxOut(Money.Coins(1), coreNode.MinerSecret.GetAddress()));

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/BlockBuilder.cs
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
 
                 // Create a valid coinbase transaction.
                 var coinbase = this.coreNode.FullNode.Network.CreateTransaction();
-                if (coinbase is IPosTrxTime posTx)
+                if (coinbase is IPosTransactionWithTime posTx)
                     posTx.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
                 coinbase.AddInput(TxIn.CreateCoinbase(chainTip.Height + 1));
                 coinbase.AddOutput(new TxOut(this.coreNode.FullNode.Network.Consensus.ProofOfWorkReward, this.coreNode.MinerSecret.GetAddress()));
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
         public static Block InvalidDuplicateCoinbase(CoreNode coreNode, Block block)
         {
             var badTxNoInputs = coreNode.FullNode.Network.CreateTransaction();
-            if (badTxNoInputs is IPosTrxTime posTx)
+            if (badTxNoInputs is IPosTransactionWithTime posTx)
                 posTx.Time = (uint)coreNode.FullNode.NodeService<IDateTimeProvider>().GetAdjustedTimeAsUnixTimestamp();
             badTxNoInputs.AddInput(new TxIn());
             badTxNoInputs.AddOutput(new TxOut(Money.Coins(1), coreNode.MinerSecret.GetAddress()));

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -720,7 +720,8 @@ namespace Stratis.Bitcoin.IntegrationTests
             });
 
             var dateTimeProvider = minerA.FullNode.NodeService<IDateTimeProvider>();
-            txThatSpendCoinstake.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
+            if(txThatSpendCoinstake is PosTransaction posTrx)
+                posTrx.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
 
 
             Coin spentCoin = new Coin(txWithBigPremine, 0);

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -720,7 +720,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             });
 
             var dateTimeProvider = minerA.FullNode.NodeService<IDateTimeProvider>();
-            if(txThatSpendCoinstake is PosTransaction posTrx)
+            if(txThatSpendCoinstake is IPosTrxTime posTrx)
                 posTrx.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
 
 

--- a/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/ConsensusManagerTests.cs
@@ -720,7 +720,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             });
 
             var dateTimeProvider = minerA.FullNode.NodeService<IDateTimeProvider>();
-            if(txThatSpendCoinstake is IPosTrxTime posTrx)
+            if(txThatSpendCoinstake is IPosTransactionWithTime posTrx)
                 posTrx.Time = (uint)dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
 
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Mempool/MemoryPoolTests.cs
@@ -366,7 +366,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
                 Transaction trx = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(context);
 
                 // This should make the mempool reject a POS trx.
-                trx.Time = Utils.DateTimeToUnixTime(Utils.UnixTimeToDateTime(trx.Time).AddMinutes(5));
+                ((PosTransaction)trx).Time = Utils.DateTimeToUnixTime(Utils.UnixTimeToDateTime(((PosTransaction)trx).Time).AddMinutes(5));
 
                 // Sign trx again after changing the time property.
                 trx = context.TransactionBuilder.SignTransaction(trx);
@@ -512,7 +512,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Mempool
                 Transaction trx = stratisSender.FullNode.WalletTransactionHandler().BuildTransaction(context);
 
                 // Use timestamp value that is definitely earlier than the input's timestamp
-                trx.Time = 1;
+                ((PosTransaction)trx).Time = 1;
 
                 // Sign trx again after mutating timestamp
                 trx = context.TransactionBuilder.SignTransaction(trx);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -874,7 +874,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 Transaction trx = stratisMiner.FullNode.WalletTransactionHandler().BuildTransaction(context);
 
                 // This should make the mempool reject a POS trx.
-                trx.Time = Utils.DateTimeToUnixTime(Utils.UnixTimeToDateTime(trx.Time).AddMinutes(5));
+                if (trx is PosTransaction posTrx)
+                    posTrx.Time = Utils.DateTimeToUnixTime(Utils.UnixTimeToDateTime(posTrx.Time).AddMinutes(5));
 
                 // Sign trx again after changing the time property.
                 trx = context.TransactionBuilder.SignTransaction(trx);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -874,7 +874,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 Transaction trx = stratisMiner.FullNode.WalletTransactionHandler().BuildTransaction(context);
 
                 // This should make the mempool reject a POS trx.
-                if (trx is PosTransaction posTrx)
+                if (trx is IPosTrxTime posTrx)
                     posTrx.Time = Utils.DateTimeToUnixTime(Utils.UnixTimeToDateTime(posTrx.Time).AddMinutes(5));
 
                 // Sign trx again after changing the time property.

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -874,7 +874,7 @@ namespace Stratis.Bitcoin.IntegrationTests
                 Transaction trx = stratisMiner.FullNode.WalletTransactionHandler().BuildTransaction(context);
 
                 // This should make the mempool reject a POS trx.
-                if (trx is IPosTrxTime posTrx)
+                if (trx is IPosTransactionWithTime posTrx)
                     posTrx.Time = Utils.DateTimeToUnixTime(Utils.UnixTimeToDateTime(posTrx.Time).AddMinutes(5));
 
                 // Sign trx again after changing the time property.

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
@@ -253,7 +253,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 resultSendingWallet.BlockIndex.Should().BeNull();
                 resultSendingWallet.BlockTime.Should().BeNull();
                 resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
-                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
+                resultSendingWallet.TransactionTime.Should().Be(((PosTransaction)trx).Time);
                 resultSendingWallet.Details.Count.Should().Be(1);
 
                 GetTransactionDetailsModel detailsSendingWallet = resultSendingWallet.Details.Single();
@@ -364,7 +364,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 resultSendingWallet.BlockIndex.Should().Be(1);
                 resultSendingWallet.BlockTime.Should().Be(blockModelAtTip.Time);
                 resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
-                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
+                resultSendingWallet.TransactionTime.Should().Be(((PosTransaction)trx).Time);
                 resultSendingWallet.Details.Count.Should().Be(1);
 
                 GetTransactionDetailsModel detailsSendingWallet = resultSendingWallet.Details.Single();
@@ -476,7 +476,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 resultSendingWallet.BlockIndex.Should().Be(1);
                 resultSendingWallet.BlockTime.Should().Be(blockModelAtTip.Time);
                 resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
-                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
+                resultSendingWallet.TransactionTime.Should().Be(((PosTransaction)trx).Time);
                 resultSendingWallet.Details.Count.Should().Be(2);
 
                 GetTransactionDetailsModel detailsSendingWalletFirstRecipient = resultSendingWallet.Details.Single(d => d.Address == unusedaddresses.First());
@@ -598,7 +598,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 resultSendingWallet.BlockIndex.Should().Be(1);
                 resultSendingWallet.BlockTime.Should().Be(blockModelAtTip.Time);
                 resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
-                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
+                resultSendingWallet.TransactionTime.Should().Be(((PosTransaction)trx).Time);
                 resultSendingWallet.Details.Count.Should().Be(2);
 
                 GetTransactionDetailsModel detailsReceivingWallet = resultSendingWallet.Details.Single(d => d.Category == GetTransactionDetailsCategoryModel.Receive);
@@ -690,7 +690,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 resultSendingWallet.BlockIndex.Should().Be(1);
                 resultSendingWallet.BlockTime.Should().Be(blockModelAtTip.Time);
                 resultSendingWallet.TimeReceived.Should().BeLessOrEqualTo(blockModelAtTip.Time);
-                resultSendingWallet.TransactionTime.Should().Be(trx.Time);
+                resultSendingWallet.TransactionTime.Should().Be(((PosTransaction)trx).Time);
                 resultSendingWallet.Details.Count.Should().Be(1);
 
                 GetTransactionDetailsModel detailsSendingWallet = resultSendingWallet.Details.Single();

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
@@ -253,7 +253,6 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 resultSendingWallet.BlockIndex.Should().BeNull();
                 resultSendingWallet.BlockTime.Should().BeNull();
                 resultSendingWallet.TimeReceived.Should().BeGreaterThan((DateTimeOffset.Now - TimeSpan.FromMinutes(1)).ToUnixTimeSeconds());
-                resultSendingWallet.TransactionTime.Should().Be(((PosTransaction)trx).Time);
                 resultSendingWallet.Details.Count.Should().Be(1);
 
                 GetTransactionDetailsModel detailsSendingWallet = resultSendingWallet.Details.Single();

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -302,7 +302,8 @@ namespace Stratis.Bitcoin.Networks
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = 1;
-            txNew.Time = nTime;
+            if (txNew is PosTransaction posTx)
+                posTx.Time = nTime;
             txNew.AddInput(new TxIn()
             {
                 ScriptSig = new Script(Op.GetPushOp(0), new Op()

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -302,7 +302,7 @@ namespace Stratis.Bitcoin.Networks
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = 1;
-            if (txNew is IPosTrxTime posTx)
+            if (txNew is IPosTransactionWithTime posTx)
                 posTx.Time = nTime;
             txNew.AddInput(new TxIn()
             {

--- a/src/Stratis.Bitcoin.Networks/StratisMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StratisMain.cs
@@ -302,7 +302,7 @@ namespace Stratis.Bitcoin.Networks
 
             Transaction txNew = consensusFactory.CreateTransaction();
             txNew.Version = 1;
-            if (txNew is PosTransaction posTx)
+            if (txNew is IPosTrxTime posTx)
                 posTx.Time = nTime;
             txNew.AddInput(new TxIn()
             {

--- a/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
+++ b/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
@@ -21,7 +21,10 @@ namespace Stratis.Bitcoin.Utilities
             this.Version = tx.Version;
             this.IsCoinbase = tx.IsCoinBase;
             this.IsCoinstake = tx.IsCoinStake;
-            this.Time = tx.Time;
+            if (tx is PosTransaction posTrx)
+            {
+                this.Time = posTrx.Time;
+            }
         }
 
         public UnspentOutputs(uint256 txId, Coins coins)

--- a/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
+++ b/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Utilities
             this.Version = tx.Version;
             this.IsCoinbase = tx.IsCoinBase;
             this.IsCoinstake = tx.IsCoinStake;
-            if (tx is IPosTrxTime posTrx)
+            if (tx is IPosTransactionWithTime posTrx)
             {
                 this.Time = posTrx.Time;
             }

--- a/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
+++ b/src/Stratis.Bitcoin/Utilities/UnspentOutputs.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Utilities
             this.Version = tx.Version;
             this.IsCoinbase = tx.IsCoinBase;
             this.IsCoinstake = tx.IsCoinStake;
-            if (tx is PosTransaction posTrx)
+            if (tx is IPosTrxTime posTrx)
             {
                 this.Time = posTrx.Time;
             }


### PR DESCRIPTION
This is the first PR in an attempt to remove the `Time` property form the transaction serialization format.

Following this PR it will be much simpler to create a POS network with the need to serialize Time in trx and achieve a serialization format similar to BTC.

**POSv4**
The on going discussion of what we call POSv4 can be found here #10 