### PR TITLE
Extend wallet account type

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
@@ -170,7 +170,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
         /// <returns>The cold staking account or <c>null</c> if the account does not exist.</returns>
         internal HdAccount GetColdStakingAccount(Wallet.Wallet wallet, bool isColdWalletAccount)
         {
-            var coinType = (CoinType)wallet.Network.Consensus.CoinType;
+            var coinType = wallet.Network.Consensus.CoinType;
             HdAccount account = wallet.GetAccount(isColdWalletAccount ? ColdWalletAccountName : HotWalletAccountName);
             if (account == null)
             {

--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingManager.cs
@@ -243,9 +243,9 @@ namespace Stratis.Bitcoin.Features.ColdStaking
         /// track addresses under the <see cref="ColdWalletAccountIndex"/> HD account.
         /// </summary>
         /// <inheritdoc />
-        public override Wallet.Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase)
+        public override Wallet.Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase, int? coinType = null)
         {
-            Wallet.Wallet wallet = base.RecoverWallet(password, name, mnemonic, creationTime, passphrase);
+            Wallet.Wallet wallet = base.RecoverWallet(password, name, mnemonic, creationTime, passphrase, coinType);
 
             this.GetOrCreateColdStakingAccount(wallet.Name, false, password);
             this.GetOrCreateColdStakingAccount(wallet.Name, true, password);

--- a/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
+++ b/src/Stratis.Bitcoin.Features.Miner.Tests/PosMintingTest.cs
@@ -275,7 +275,7 @@ namespace Stratis.Bitcoin.Features.Miner.Tests
             account.ExternalAddresses.Add(new HdAddress { Index = 2, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(18), Index = 0, Amount = 2 * Money.CENT } } });
             account.ExternalAddresses.Add(new HdAddress { Index = 3, Transactions = new List<TransactionData> { new TransactionData { Id = new uint256(19), Index = 0, Amount = 1 * Money.NANO } } });
             account.ExternalAddresses.Add(new HdAddress { Index = 4, Transactions = null });
-            wallet.AccountsRoot.Add(new AccountRoot() { Accounts = new[] { account }, CoinType = CoinType.Stratis });
+            wallet.AccountsRoot.Add(new AccountRoot() { Accounts = new[] { account }, CoinType = KnownCoinTypes.Stratis });
         }
 
         // the difficulty tests are ported from: https://github.com/bitcoin/bitcoin/blob/3e1ee310437f4c93113f6121425beffdc94702c2/src/test/blockchain_tests.cpp

--- a/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/WalletInfoBroadcaster.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Broadcasters/WalletInfoBroadcaster.cs
@@ -54,7 +54,7 @@ namespace Stratis.Bitcoin.Features.SignalR.Broadcasters
 
                         var accountBalanceModel = new AccountBalanceModel
                         {
-                            CoinType = (CoinType) wallet.Network.Consensus.CoinType,
+                            CoinType =  wallet.Network.Consensus.CoinType,
                             Name = account.Name,
                             HdPath = account.HdPath,
                             AmountConfirmed = balance.AmountConfirmed,

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/AccountRootTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/AccountRootTest.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using Stratis.Bitcoin.Tests.Common;
+using Xunit;
 
 namespace Stratis.Bitcoin.Features.Wallet.Tests
 {
@@ -7,7 +8,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void GetFirstUnusedAccountWithoutAccountsReturnsNull()
         {
-            AccountRoot accountRoot = CreateAccountRoot(CoinType.Stratis);
+            AccountRoot accountRoot = CreateAccountRoot(KnownCoinTypes.Stratis);
 
             HdAccount result = accountRoot.GetFirstUnusedAccount();
 
@@ -17,7 +18,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void GetFirstUnusedAccountReturnsAccountWithLowerIndexHavingNoAddresses()
         {
-            AccountRoot accountRoot = CreateAccountRoot(CoinType.Stratis);
+            AccountRoot accountRoot = CreateAccountRoot(KnownCoinTypes.Stratis);
             HdAccount unused = CreateAccount("unused1");
             unused.Index = 2;
             accountRoot.Accounts.Add(unused);
@@ -46,7 +47,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void GetAccountByNameWithMatchingNameReturnsAccount()
         {
-            AccountRoot accountRoot = CreateAccountRootWithHdAccountHavingAddresses("Test", CoinType.Stratis);
+            AccountRoot accountRoot = CreateAccountRootWithHdAccountHavingAddresses("Test", KnownCoinTypes.Stratis);
 
             HdAccount result = accountRoot.GetAccountByName("Test");
 
@@ -57,7 +58,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void GetAccountByNameWithNonMatchingNameReturnsNull()
         {
-            AccountRoot accountRoot = CreateAccountRootWithHdAccountHavingAddresses("Test", CoinType.Stratis);
+            AccountRoot accountRoot = CreateAccountRootWithHdAccountHavingAddresses("Test", KnownCoinTypes.Stratis);
 
             Assert.Null(accountRoot.GetAccountByName("test"));
         }

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/HdAccountTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/HdAccountTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
+using Stratis.Bitcoin.Tests.Common;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Wallet.Tests
@@ -14,9 +15,9 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var account = new HdAccount();
             account.HdPath = "1/2/105";
 
-            CoinType result = account.GetCoinType();
+            int result = account.GetCoinType();
 
-            Assert.Equal(CoinType.Stratis, result);
+            Assert.Equal(KnownCoinTypes.Stratis, result);
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -720,7 +720,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
                 AccountsRoot = new List<AccountRoot> {
                     new AccountRoot()
                     {
-                        CoinType = (CoinType)this.Network.Consensus.CoinType,
+                        CoinType = this.Network.Consensus.CoinType,
                         LastBlockSyncedHeight = 15
                     }
                 }

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletControllerTest.cs
@@ -220,7 +220,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             var mnemonic = new Mnemonic(Wordlist.English, WordCount.Twelve);
             var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>())).Returns(mnemonic);
+            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null)).Returns(mnemonic);
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
 
@@ -266,7 +266,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             string errorMessage = "An error occurred.";
             var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>()))
+            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null))
                 .Throws(new WalletException(errorMessage));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -292,7 +292,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void CreateWalletWithNotSupportedExceptionExceptionReturnsBadRequest()
         {
             var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>()))
+            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null))
                 .Throws(new NotSupportedException("Not supported"));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -324,7 +324,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
 
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null)).Returns(wallet);
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null)).Returns(wallet);
 
             Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
             walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
@@ -362,7 +362,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             DateTime lastBlockDateTime = chainIndexer.Tip.Header.BlockTime.DateTime;
 
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null)).Returns(wallet);
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null)).Returns(wallet);
 
             Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
             walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
@@ -413,7 +413,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         {
             string errorMessage = "An error occurred.";
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null))
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null))
                 .Throws(new WalletException(errorMessage));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -439,7 +439,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void RecoverWalletWithFileNotFoundExceptionReturnsNotFound()
         {
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null))
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null))
                 .Throws(new FileNotFoundException("File not found."));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -466,7 +466,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void RecoverWalletWithExceptionReturnsBadRequest()
         {
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null))
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null))
                 .Throws(new FormatException("Formatting failed."));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletManagerTest.cs
@@ -78,7 +78,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             for (int i = 0; i < expectedWallet.AccountsRoot.Count; i++)
             {
-                Assert.Equal(CoinType.Stratis, expectedWallet.AccountsRoot.ElementAt(i).CoinType);
+                Assert.Equal(KnownCoinTypes.Stratis, expectedWallet.AccountsRoot.ElementAt(i).CoinType);
                 Assert.Equal(1, expectedWallet.AccountsRoot.ElementAt(i).LastBlockSyncedHeight);
                 Assert.Equal(block.GetHash(), expectedWallet.AccountsRoot.ElementAt(i).LastBlockSyncedHash);
 
@@ -190,7 +190,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             for (int i = 0; i < expectedWallet.AccountsRoot.Count; i++)
             {
-                Assert.Equal(CoinType.Stratis, expectedWallet.AccountsRoot.ElementAt(i).CoinType);
+                Assert.Equal(KnownCoinTypes.Stratis, expectedWallet.AccountsRoot.ElementAt(i).CoinType);
                 Assert.Equal(1, expectedWallet.AccountsRoot.ElementAt(i).LastBlockSyncedHeight);
                 Assert.Equal(block.GetHash(), expectedWallet.AccountsRoot.ElementAt(i).LastBlockSyncedHash);
 
@@ -1094,7 +1094,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, this.Network, new Mock<ChainIndexer>().Object, new WalletSettings(NodeSettings.Default(this.Network)),
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncProvider>().Object, new NodeLifetime(), DateTimeProvider.Default, new ScriptAddressReader());
             Wallet wallet = this.walletFixture.GenerateBlankWallet("myWallet", "password");
-            wallet.AccountsRoot.ElementAt(0).CoinType = CoinType.Stratis;
+            wallet.AccountsRoot.ElementAt(0).CoinType = KnownCoinTypes.Stratis;
             walletManager.Wallets.Add(wallet);
 
             int result = walletManager.LastBlockHeight();
@@ -1129,7 +1129,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             var walletManager = new WalletManager(this.LoggerFactory.Object, this.Network, chainIndexer, new WalletSettings(NodeSettings.Default(this.Network)),
                 CreateDataFolder(this), new Mock<IWalletFeePolicy>().Object, new Mock<IAsyncProvider>().Object, new NodeLifetime(), DateTimeProvider.Default, new ScriptAddressReader());
             Wallet wallet = this.walletFixture.GenerateBlankWallet("myWallet", "password");
-            wallet.AccountsRoot.ElementAt(0).CoinType = CoinType.Stratis;
+            wallet.AccountsRoot.ElementAt(0).CoinType = KnownCoinTypes.Stratis;
             walletManager.Wallets.Add(wallet);
 
             uint256 result = walletManager.LastReceivedBlockInfo().Hash;
@@ -1175,7 +1175,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 
             wallet.AccountsRoot.Add(new AccountRoot()
             {
-                CoinType = CoinType.Stratis,
+                CoinType = KnownCoinTypes.Stratis,
                 Accounts = new List<HdAccount>
                 {
                     new HdAccount {
@@ -1186,7 +1186,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             });
 
             Wallet wallet2 = this.walletFixture.GenerateBlankWallet("myWallet2", "password");
-            wallet2.AccountsRoot.ElementAt(0).CoinType = CoinType.Stratis;
+            wallet2.AccountsRoot.ElementAt(0).CoinType = KnownCoinTypes.Stratis;
             wallet2.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 ExternalAddresses = WalletTestsHelpers.CreateUnspentTransactionsOfBlockHeights(KnownNetworks.StratisMain, 1, 3, 5, 7, 9, 10),
@@ -2812,7 +2812,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void CreateBip44PathWithChangeAddressReturnsPath()
         {
-            string result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, true, 3);
+            string result = HdOperations.CreateHdPath((int)KnownCoinTypes.Stratis, 4, true, 3);
 
             Assert.Equal("m/44'/105'/4'/1/3", result);
         }
@@ -2820,7 +2820,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         [Fact]
         public void CreateBip44PathWithoutChangeAddressReturnsPath()
         {
-            string result = HdOperations.CreateHdPath((int)CoinType.Stratis, 4, false, 3);
+            string result = HdOperations.CreateHdPath((int)KnownCoinTypes.Stratis, 4, false, 3);
 
             Assert.Equal("m/44'/105'/4'/0/3", result);
         }

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
+using Stratis.Bitcoin.Tests.Common;
 using Xunit;
 
 namespace Stratis.Bitcoin.Features.Wallet.Tests
@@ -21,7 +22,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void GetAllTransactionsReturnsTransactionsFromWallet()
         {
             var wallet = new Wallet();
-            AccountRoot stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis);
+            AccountRoot stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", KnownCoinTypes.Stratis);
 
             TransactionData transaction1 = CreateTransaction(new uint256(1), new Money(15000), 1);
             TransactionData transaction2 = CreateTransaction(new uint256(2), new Money(91209), 1);
@@ -52,7 +53,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
         public void GetAllPubKeysReturnsPubkeysFromWallet()
         {
             var wallet = new Wallet();
-            AccountRoot stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", CoinType.Stratis);
+            AccountRoot stratisAccountRoot = CreateAccountRootWithHdAccountHavingAddresses("StratisAccount", KnownCoinTypes.Stratis);
             wallet.AccountsRoot.Add(stratisAccountRoot);
 
             List<Script> result = wallet.GetAllPubKeys().ToList();

--- a/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestBase.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet.Tests/WalletTestBase.cs
@@ -7,7 +7,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
 {
     public class WalletTestBase
     {
-        public static AccountRoot CreateAccountRoot(CoinType coinType)
+        public static AccountRoot CreateAccountRoot(int coinType)
         {
             return new AccountRoot()
             {
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Tests
             };
         }
 
-        public static AccountRoot CreateAccountRootWithHdAccountHavingAddresses(string accountName, CoinType coinType)
+        public static AccountRoot CreateAccountRootWithHdAccountHavingAddresses(string accountName, int coinType)
         {
             return new AccountRoot()
             {

--- a/src/Stratis.Bitcoin.Features.Wallet/AddressBalance.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/AddressBalance.cs
@@ -15,7 +15,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// The coin type of this balance.
         /// </summary>
-        public CoinType CoinType { get; set; }
+        public int CoinType { get; set; }
 
         /// <summary>
         /// The balance of confirmed transactions.

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -287,7 +287,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
             try
             {
-                Wallet wallet = this.walletManager.RecoverWallet(request.Password, request.Name, request.Mnemonic, request.CreationDate, passphrase: request.Passphrase);
+                Wallet wallet = this.walletManager.RecoverWallet(request.Password, request.Name, request.Mnemonic, request.CreationDate, passphrase: request.Passphrase, request.CoinType);
 
                 this.SyncFromBestHeightForRecoveredWallets(request.CreationDate);
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
 
         private readonly IWalletSyncManager walletSyncManager;
 
-        private readonly CoinType coinType;
+        private readonly int coinType;
 
         /// <summary>Specification of the network the node runs on - regtest/testnet/mainnet.</summary>
         private readonly Network network;
@@ -67,7 +67,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             this.walletSyncManager = walletSyncManager;
             this.connectionManager = connectionManager;
             this.network = network;
-            this.coinType = (CoinType)network.Consensus.CoinType;
+            this.coinType = network.Consensus.CoinType;
             this.chainIndexer = chainIndexer;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.broadcasterManager = broadcasterManager;

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -75,8 +75,9 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="name">The name of the wallet.</param>
         /// <param name="passphrase">The passphrase used in the seed.</param>
         /// <param name="mnemonic">The user's mnemonic for the wallet.</param>
+        /// <param name="coinType">Allow to override the default BIP44 cointype.</param>
         /// <returns>A mnemonic defining the wallet's seed used to generate addresses.</returns>
-        Mnemonic CreateWallet(string password, string name, string passphrase = null, Mnemonic mnemonic = null);
+        Mnemonic CreateWallet(string password, string name, string passphrase = null, Mnemonic mnemonic = null, int? coinType = null);
 
         /// <summary>
         /// Signs a string message.
@@ -127,8 +128,9 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="mnemonic">The user's mnemonic for the wallet.</param>
         /// <param name="passphrase">The passphrase used in the seed.</param>
         /// <param name="creationTime">The date and time this wallet was created.</param>
+        /// <param name="coinType">Allow to override the default BIP44 cointype.</param>
         /// <returns>The recovered wallet.</returns>
-        Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase = null);
+        Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase = null, int? coinType = null);
 
         /// <summary>
         /// Recovers a wallet using extended public key and account index.

--- a/src/Stratis.Bitcoin.Features.Wallet/KnownCoinTypes.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/KnownCoinTypes.cs
@@ -1,0 +1,24 @@
+﻿namespace Stratis.Bitcoin.Features.Wallet
+{
+    /// <summary>
+    /// The type of coin, as specified in BIP44.
+    /// </summary>
+    /// <remarks>For more, see https://github.com/satoshilabs/slips/blob/master/slip-0044.md</remarks>
+    //public class KnownCoinTypes
+    //{
+    //    /// <summary>
+    //    /// Bitcoin
+    //    /// </summary>
+    //    public const int Bitcoin = 0;
+
+    //    /// <summary>
+    //    /// Testnet (all coins)
+    //    /// </summary>
+    //    public const int Testnet = 1;
+
+    //    /// <summary>
+    //    /// Stratis
+    //    /// </summary>
+    //    public const int Stratis = 105;
+    //}
+}

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/AddressBalanceModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/AddressBalanceModel.cs
@@ -9,7 +9,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string Address { get; set; }
 
         [JsonProperty(PropertyName = "coinType")]
-        public CoinType CoinType { get; set; }
+        public int CoinType { get; set; }
 
         [JsonProperty(PropertyName = "amountConfirmed")]
         public Money AmountConfirmed { get; set; }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -119,6 +119,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
 
         [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTime CreationDate { get; set; }
+
+        /// <summary>
+        /// Optional CoinType to overwrite the default <see cref="NBitcoin.IConsensus.CoinType"/>.
+        /// </summary>
+        public int? CoinType { get; set; }
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletBalanceModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletBalanceModel.cs
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string HdPath { get; set; }
 
         [JsonProperty(PropertyName = "coinType")]
-        public CoinType CoinType { get; set; }
+        public int CoinType { get; set; }
 
         [JsonProperty(PropertyName = "amountConfirmed")]
         public Money AmountConfirmed { get; set; }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletHistoryModel.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string HdPath { get; set; }
 
         [JsonProperty(PropertyName = "coinType")]
-        public CoinType CoinType { get; set; }
+        public int CoinType { get; set; }
 
         [JsonProperty(PropertyName = "transactionsHistory")]
         public ICollection<TransactionItemModel> TransactionsHistory { get; set; }

--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -365,7 +365,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// The type of coin, Bitcoin or Stratis.
         /// </summary>
         [JsonProperty(PropertyName = "coinType")]
-        public CoinType CoinType { get; set; }
+        public int CoinType { get; set; }
 
         /// <summary>
         /// The height of the last block that was synced.
@@ -602,10 +602,10 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <summary>
         /// Gets the type of coin this account is for.
         /// </summary>
-        /// <returns>A <see cref="CoinType"/>.</returns>
-        public CoinType GetCoinType()
+        /// <returns>A BIP44 CoinType.</returns>
+        public int GetCoinType()
         {
-            return (CoinType)HdOperations.GetCoinType(this.HdPath);
+            return HdOperations.GetCoinType(this.HdPath);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -266,7 +266,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public Mnemonic CreateWallet(string password, string name, string passphrase, Mnemonic mnemonic = null)
+        public Mnemonic CreateWallet(string password, string name, string passphrase, Mnemonic mnemonic = null, int? coinType = null)
         {
             Guard.NotEmpty(password, nameof(password));
             Guard.NotEmpty(name, nameof(name));
@@ -280,7 +280,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             // Create a wallet file.
             string encryptedSeed = extendedKey.PrivateKey.GetEncryptedBitcoinSecret(password, this.network).ToWif();
-            Wallet wallet = this.GenerateWalletFile(name, encryptedSeed, extendedKey.ChainCode);
+            Wallet wallet = this.GenerateWalletFile(name, encryptedSeed, extendedKey.ChainCode, coinType: coinType);
 
             // Generate multiple accounts and addresses from the get-go.
             for (int i = 0; i < WalletCreationAccountsCount; i++)
@@ -416,7 +416,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public virtual Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase)
+        public virtual Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase, int? coinType = null)
         {
             Guard.NotEmpty(password, nameof(password));
             Guard.NotEmpty(name, nameof(name));
@@ -442,7 +442,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             // Create a wallet file.
             string encryptedSeed = extendedKey.PrivateKey.GetEncryptedBitcoinSecret(password, this.network).ToWif();
-            Wallet wallet = this.GenerateWalletFile(name, encryptedSeed, extendedKey.ChainCode, creationTime);
+            Wallet wallet = this.GenerateWalletFile(name, encryptedSeed, extendedKey.ChainCode, creationTime, coinType);
 
             // Generate multiple accounts and addresses from the get-go.
             for (int i = 0; i < WalletRecoveryAccountsCount; i++)

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -63,7 +63,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         public ConcurrentBag<Wallet> Wallets { get; }
 
         /// <summary>The type of coin used in this manager.</summary>
-        protected readonly CoinType coinType;
+        protected readonly int coinType;
 
         /// <summary>Specification of the network the node runs on - regtest/testnet/mainnet.</summary>
         protected readonly Network network;
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.Wallets = new ConcurrentBag<Wallet>();
 
             this.network = network;
-            this.coinType = (CoinType)network.Consensus.CoinType;
+            this.coinType = network.Consensus.CoinType;
             this.ChainIndexer = chainIndexer;
             this.asyncProvider = asyncProvider;
             this.nodeLifetime = nodeLifetime;
@@ -1406,9 +1406,10 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <param name="encryptedSeed">The seed for this wallet, password encrypted.</param>
         /// <param name="chainCode">The chain code.</param>
         /// <param name="creationTime">The time this wallet was created.</param>
+        /// <param name="coinType">A BIP44 coin type, this will allow to overwrite the default network coin type.</param>
         /// <returns>The wallet object that was saved into the file system.</returns>
         /// <exception cref="WalletException">Thrown if wallet cannot be created.</exception>
-        private Wallet GenerateWalletFile(string name, string encryptedSeed, byte[] chainCode, DateTimeOffset? creationTime = null)
+        private Wallet GenerateWalletFile(string name, string encryptedSeed, byte[] chainCode, DateTimeOffset? creationTime = null, int? coinType = null)
         {
             Guard.NotEmpty(name, nameof(name));
             Guard.NotEmpty(encryptedSeed, nameof(encryptedSeed));
@@ -1437,7 +1438,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 ChainCode = chainCode,
                 CreationTime = creationTime ?? this.dateTimeProvider.GetTimeOffset(),
                 Network = this.network,
-                AccountsRoot = new List<AccountRoot> { new AccountRoot() { Accounts = new List<HdAccount>(), CoinType = this.coinType } },
+                AccountsRoot = new List<AccountRoot> { new AccountRoot() { Accounts = new List<HdAccount>(), CoinType = coinType ?? this.coinType } },
             };
 
             // Create a folder if none exists and persist the file.

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
@@ -105,7 +105,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         {
             ExtKey xPrivKey = node.Mnemonic.DeriveExtKey(WalletPassphrase);
             Key privateKey = xPrivKey.PrivateKey;
-            ExtPubKey xPublicKey = HdOperations.GetExtendedPublicKey(privateKey, xPrivKey.ChainCode, (int)CoinType.Bitcoin, 0);
+            ExtPubKey xPublicKey = HdOperations.GetExtendedPublicKey(privateKey, xPrivKey.ChainCode, KnownCoinTypes.Bitcoin, 0);
             return xPublicKey;
         }
 

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletOperationsTests.cs
@@ -15,6 +15,7 @@ using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.Bitcoin.Networks;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities.JsonErrors;
 using Xunit;
 
@@ -179,7 +180,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             account.InternalAddresses.Count().Should().Be(20);
             account.Index.Should().Be(0);
             account.ExtendedPubKey.Should().NotBeNullOrEmpty();
-            account.GetCoinType().Should().Be(CoinType.Stratis);
+            account.GetCoinType().Should().Be(KnownCoinTypes.Stratis);
             account.HdPath.Should().Be("m/44'/105'/0'");
         }
 
@@ -230,7 +231,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             account.InternalAddresses.Count().Should().Be(20);
             account.Index.Should().Be(0);
             account.ExtendedPubKey.Should().NotBeNullOrEmpty();
-            account.GetCoinType().Should().Be(CoinType.Stratis);
+            account.GetCoinType().Should().Be(KnownCoinTypes.Stratis);
             account.HdPath.Should().Be("m/44'/105'/0'");
         }
 
@@ -285,7 +286,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             account.InternalAddresses.Count().Should().Be(20);
             account.Index.Should().Be(0);
             account.ExtendedPubKey.Should().NotBeNullOrEmpty();
-            account.GetCoinType().Should().Be(CoinType.Stratis);
+            account.GetCoinType().Should().Be(KnownCoinTypes.Stratis);
             account.HdPath.Should().Be("m/44'/105'/0'");
         }
 
@@ -336,7 +337,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             account.InternalAddresses.Count().Should().Be(20);
             account.Index.Should().Be(0);
             account.ExtendedPubKey.Should().NotBeNullOrEmpty();
-            account.GetCoinType().Should().Be(CoinType.Stratis);
+            account.GetCoinType().Should().Be(KnownCoinTypes.Stratis);
             account.HdPath.Should().Be("m/44'/105'/0'");
         }
 
@@ -384,7 +385,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             account.InternalAddresses.Count().Should().Be(20);
             account.Index.Should().Be(0);
             account.ExtendedPubKey.Should().NotBeNullOrEmpty();
-            account.GetCoinType().Should().Be(CoinType.Stratis);
+            account.GetCoinType().Should().Be(KnownCoinTypes.Stratis);
             account.HdPath.Should().Be("m/44'/105'/0'");
         }
 
@@ -782,7 +783,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             account.InternalAddresses.Count().Should().Be(20);
             account.Index.Should().Be(0);
             account.ExtendedPubKey.Should().NotBeNullOrEmpty();
-            account.GetCoinType().Should().Be(CoinType.Stratis);
+            account.GetCoinType().Should().Be(KnownCoinTypes.Stratis);
             account.HdPath.Should().Be("m/44'/105'/0'");
         }
 
@@ -827,7 +828,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             account.InternalAddresses.Count().Should().Be(20);
             account.Index.Should().Be(0);
             account.ExtendedPubKey.Should().NotBeNullOrEmpty();
-            account.GetCoinType().Should().Be(CoinType.Stratis);
+            account.GetCoinType().Should().Be(KnownCoinTypes.Stratis);
             account.HdPath.Should().Be("m/44'/105'/0'");
         }
 
@@ -895,7 +896,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
             var accountBalance = response.AccountsBalances.Single();
             accountBalance.HdPath.Should().Be("m/44'/105'/0'");
             accountBalance.Name.Should().Be("account 0");
-            accountBalance.CoinType.Should().Be(CoinType.Stratis);
+            accountBalance.CoinType.Should().Be(KnownCoinTypes.Stratis);
             accountBalance.AmountConfirmed.Should().Be(new Money(142190299995400));
             accountBalance.AmountUnconfirmed.Should().Be(new Money(100000000000));
         }
@@ -958,7 +959,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 .GetJsonAsync<AddressBalanceModel>();
 
             addressBalance.Address.Should().Be(address);
-            addressBalance.CoinType.Should().Be(CoinType.Stratis);
+            addressBalance.CoinType.Should().Be(KnownCoinTypes.Stratis);
             addressBalance.AmountConfirmed.Should().Be(new Money(10150100000000));
             addressBalance.AmountUnconfirmed.Should().Be(Money.Zero);
 

--- a/src/Stratis.Bitcoin.Tests.Common/KnownCoinTypes.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/KnownCoinTypes.cs
@@ -1,24 +1,24 @@
-﻿namespace Stratis.Bitcoin.Features.Wallet
+﻿namespace Stratis.Bitcoin.Tests.Common
 {
     /// <summary>
     /// The type of coin, as specified in BIP44.
     /// </summary>
     /// <remarks>For more, see https://github.com/satoshilabs/slips/blob/master/slip-0044.md</remarks>
-    public enum CoinType
+    public class KnownCoinTypes
     {
         /// <summary>
         /// Bitcoin
         /// </summary>
-        Bitcoin = 0,
+        public const int Bitcoin = 0;
 
         /// <summary>
         /// Testnet (all coins)
         /// </summary>
-        Testnet = 1,
+        public const int Testnet = 1;
 
         /// <summary>
         /// Stratis
         /// </summary>
-        Stratis = 105
+        public const int Stratis = 105;
     }
 }

--- a/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
+++ b/src/Stratis.Bitcoin.Tests.Wallet.Common/WalletTestsHelpers.cs
@@ -154,7 +154,7 @@ namespace Stratis.Bitcoin.Tests.Wallet.Common
                 ChainCode = extendedKey.ChainCode,
                 CreationTime = DateTimeOffset.Now,
                 Network = KnownNetworks.Main,
-                AccountsRoot = new List<AccountRoot> { new AccountRoot() { Accounts = new List<HdAccount>(), CoinType = (CoinType)KnownNetworks.Main.Consensus.CoinType } },
+                AccountsRoot = new List<AccountRoot> { new AccountRoot() { Accounts = new List<HdAccount>(), CoinType = KnownNetworks.Main.Consensus.CoinType } },
             };
 
             return (walletFile, extendedKey);
@@ -210,7 +210,7 @@ namespace Stratis.Bitcoin.Tests.Wallet.Common
             {
                 wallet.AccountsRoot.Add(new AccountRoot()
                 {
-                    CoinType = CoinType.Bitcoin,
+                    CoinType = KnownCoinTypes.Bitcoin,
                     Accounts = new List<HdAccount>
                     {
                         new HdAccount


### PR DESCRIPTION
**Purpose** 
This PR is to allow the creation of wallets with a different account type from the default specified in Network.

**Usage and use-case**
This is useful for airdrop scenarios where coin are airdropped on private keys in a derivation path that belongs to another coin.

**Testing**
- Wallet integration tests passed
- Wallet Unit tests passed
- This is not properly tested yet (it will be tested as part of the ObsidianX airdrop testing)

