### PR TITLE
Added workflow to publish release nuget packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 on: 
-  push:    
+  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -1,4 +1,4 @@
-name: Publish Packages
+name: Publish Pre-Release Packages
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  publishPackages:
+  publishPreReleasePackages:
 
     runs-on: windows-latest
     
@@ -24,15 +24,19 @@ jobs:
       uses: actions/setup-dotnet@v1
 
     - name: Generate build number
-      uses: einaregilsson/build-number@v2 
+      uses: zyborg/gh-action-buildnum@v1.1.0 
       with:
-        token: ${{secrets.GITHUB_TOKEN}}   
+        gist_token: ${{ secrets.GIST_TOKEN }}
+        set_env: true
                                             
     - name: Setup NuGet.exe
       uses: NuGet/setup-nuget@v1.0.2
 
     - name: Set GITHUB_OWNER
       run: echo "::set-env name=GITHUB_OWNER::$(echo ${{github.repository}} | cut -d "/" -f 1)"
+
+    - name: Override bash shell PATH (workaround issue - tinyurl.com/w3dbtou)
+      run: echo "::add-path::C:\Program Files\Git\bin"
 
     - name: Update Directory.Build.props for Push
       run: |
@@ -43,7 +47,7 @@ jobs:
       shell: bash
 
     - name: Nuget Pack
-      run: dotnet pack --include-source --include-symbols --version-suffix "${{env.NUGET_RELEASE_TYPE}}${{env.BUILD_NUMBER}}" --configuration ${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_PATH }}
+      run: dotnet pack --include-source --include-symbols --version-suffix "${{env.NUGET_RELEASE_TYPE}}${{ steps.lastBuildNum.outputs.workflow_buildnum }}" --configuration ${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_PATH }}
 
     - name: Nuget Add Source
       run: nuget sources add -name "GPR" -Source "https://nuget.pkg.github.com/${{env.GITHUB_OWNER}}/index.json" -Username "${{env.GITHUB_OWNER}}" -Password ${{secrets.GITHUB_TOKEN}} 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,46 @@
+name: Publish Release Packages
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+
+  publishPackages:
+
+    runs-on: windows-latest
+    
+    env:
+      SOLUTION_PATH: 'src/Blockcore.sln'
+      BUILD_CONFIGURATION: 'Debug'
+
+    steps:
+
+    - uses: actions/checkout@v1
+      
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+                                            
+    - name: Setup NuGet.exe
+      uses: NuGet/setup-nuget@v1.0.2
+
+    - name: Set GITHUB_OWNER
+      run: echo "::set-env name=GITHUB_OWNER::$(echo ${{github.repository}} | cut -d "/" -f 1)"
+
+    - name: Override bash shell PATH (workaround issue - tinyurl.com/w3dbtou)
+      run: echo "::add-path::C:\Program Files\Git\bin"
+    
+    - name: Update Directory.Build.props for Push
+      run: |
+        find . -name 'Directory.Build.props' -print0 | while read -d $'\0' file
+        do
+          sed -i 's,</IsPackable>,</IsPackable>\n\t<RepositoryType>git</RepositoryType>\n\t<RepositoryUrl>git://github.com/${{github.repository}}</RepositoryUrl>,g' $file
+        done
+      shell: bash
+
+    - name: Nuget Pack
+      run: dotnet pack --configuration ${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_PATH}}
+
+    - name: Nuget Push
+      run: nuget push **/*.nupkg -ApiKey ${{secrets.NUGET_KEY}} -Source "https://api.nuget.org/v3/index.json" -SkipDuplicate -NoSymbols

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/block-core/blockcore/workflows/Build/badge.svg)](https://github.com/block-core/blockcore/actions)   [![Integration Test Status](https://github.com/block-core/blockcore/workflows/Integration%20Test/badge.svg)](https://github.com/block-core/blockcore/actions)   [![Publish Packages Status](https://github.com/block-core/blockcore/workflows/Publish%20Packages/badge.svg)](https://github.com/block-core/blockcore/actions)
+[![Build Status](https://github.com/block-core/blockcore/workflows/Build/badge.svg)](https://github.com/block-core/blockcore/actions)   [![Integration Test Status](https://github.com/block-core/blockcore/workflows/Integration%20Test/badge.svg)](https://github.com/block-core/blockcore/actions)
 
 Blockcore
 ===============

--- a/src/FodyNlogAdapter/FodyNlogAdapter.csproj
+++ b/src/FodyNlogAdapter/FodyNlogAdapter.csproj
@@ -5,7 +5,8 @@
     <AssemblyName>FodyNlogAdapter</AssemblyName>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>Blockcore.FodyNlogAdapter</PackageId>
     <Product>Stratis.FodyNlogAdapter</Product>
   </PropertyGroup>

--- a/src/NBitcoin/NBitcoin.csproj
+++ b/src/NBitcoin/NBitcoin.csproj
@@ -1,17 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <Company>NStratis</Company>
-    <Copyright>Copyright © Stratis Platform SA 2017</Copyright>
-    <Description>The C# Bitcoin Library based on NBitcoin</Description>
-  </PropertyGroup>
-  
-
   
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
-    
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>    
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PackageId>Blockcore.NBitcoin</PackageId>
     <RootNamespace>NBitcoin</RootNamespace>

--- a/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
+++ b/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
@@ -15,10 +15,9 @@
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />
-    <!-- Force packing of a web project https://github.com/aspnet/websdk/issues/228 -->
-    <IsPackable>true</IsPackable>
-    <Authors>Stratis Group Ltd.</Authors>
-  </PropertyGroup> 
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile></DocumentationFile>

--- a/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DBreeze" Version="1.89.0" />

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Stratis.Bitcoin.Features.ColdStaking.csproj
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Stratis.Bitcoin.Features.ColdStaking.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.ColdStaking</AssemblyName>
     <PackageId>Blockcore.Features.ColdStaking</PackageId>
@@ -10,7 +10,8 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
+++ b/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features Consensus</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.Consensus</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.Consensus</AssemblyName>
     <PackageId>Blockcore.Features.Consensus</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
+++ b/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features Dns</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.Dns</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.Dns</AssemblyName>
     <PackageId>Blockcore.Features.Dns</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Features.LightWallet/Stratis.Bitcoin.Features.LightWallet.csproj
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Stratis.Bitcoin.Features.LightWallet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.LightWallet</AssemblyName>
     <PackageId>Blockcore.Features.LightWallet</PackageId>
@@ -10,7 +10,8 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features MemoryPool</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.MemoryPool</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.MemoryPool</AssemblyName>
     <PackageId>Blockcore.Features.MemoryPool</PackageId>
@@ -20,7 +20,8 @@
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />

--- a/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
+++ b/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features Miner</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.Miner</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.Miner</AssemblyName>
     <PackageId>Blockcore.Features.Miner</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
+++ b/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features Notifications</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.Notifications</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.Notifications</AssemblyName>
     <PackageId>Blockcore.Features.Notifications</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />

--- a/src/Stratis.Bitcoin.Features.PoA/Stratis.Bitcoin.Features.PoA.csproj
+++ b/src/Stratis.Bitcoin.Features.PoA/Stratis.Bitcoin.Features.PoA.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features PoA</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.PoA</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.PoA</AssemblyName>
     <PackageId>Blockcore.Features.PoA</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
+++ b/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features RPC</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.RPC</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.RPC</AssemblyName>
     <PackageId>Blockcore.Features.RPC</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
+++ b/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features Wallet</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.Wallet</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.Wallet</AssemblyName>
     <PackageId>Blockcore.Features.Wallet</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/Stratis.Bitcoin.Features.WatchOnlyWallet.csproj
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/Stratis.Bitcoin.Features.WatchOnlyWallet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Stratis Bitcoin Features WatchOnlyWallet</Description>
     <AssemblyTitle>Stratis.Bitcoin.Features.WatchOnlyWallet</AssemblyTitle>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <AssemblyName>Stratis.Bitcoin.Features.WatchOnlyWallet</AssemblyName>
     <PackageId>Blockcore.Features.WatchOnlyWallet</PackageId>
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
@@ -15,7 +15,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Product />
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Networks/Stratis.Bitcoin.Networks.csproj
+++ b/src/Stratis.Bitcoin.Networks/Stratis.Bitcoin.Networks.csproj
@@ -17,7 +17,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Tests.Common/Stratis.Bitcoin.Tests.Common.csproj
+++ b/src/Stratis.Bitcoin.Tests.Common/Stratis.Bitcoin.Tests.Common.csproj
@@ -15,6 +15,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin.Tests.Wallet.Common/Stratis.Bitcoin.Tests.Wallet.Common.csproj
+++ b/src/Stratis.Bitcoin.Tests.Wallet.Common/Stratis.Bitcoin.Tests.Wallet.Common.csproj
@@ -15,6 +15,8 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -18,7 +18,8 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>..\Stratis.ruleset</CodeAnalysisRuleSet>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Features.Collateral/Stratis.Features.Collateral.csproj
+++ b/src/Stratis.Features.Collateral/Stratis.Features.Collateral.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Features.FederatedPeg/Stratis.Features.FederatedPeg.csproj
+++ b/src/Stratis.Features.FederatedPeg/Stratis.Features.FederatedPeg.csproj
@@ -5,7 +5,8 @@
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <DebugType>Full</DebugType>
     <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Version>3.0.6.0-beta</Version>
   </PropertyGroup>
 

--- a/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
+++ b/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
@@ -6,7 +6,8 @@
     <DebugType>Full</DebugType>
     <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
+++ b/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.SmartContracts.CLR/Stratis.SmartContracts.CLR.csproj
+++ b/src/Stratis.SmartContracts.CLR/Stratis.SmartContracts.CLR.csproj
@@ -6,7 +6,8 @@
     <AssemblyVersion>1.0.2.0</AssemblyVersion>
     <FileVersion>1.0.2.0</FileVersion>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Product>Stratis.SmartContracts.CLR</Product>
   </PropertyGroup>
 

--- a/src/Stratis.SmartContracts.Core/Stratis.SmartContracts.Core.csproj
+++ b/src/Stratis.SmartContracts.Core/Stratis.SmartContracts.Core.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
-    <Company>Stratis Group Ltd.</Company>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.SmartContracts.Networks/Stratis.SmartContracts.Networks.csproj
+++ b/src/Stratis.SmartContracts.Networks/Stratis.SmartContracts.Networks.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.SmartContracts.RuntimeObserver/Stratis.SmartContracts.RuntimeObserver.csproj
+++ b/src/Stratis.SmartContracts.RuntimeObserver/Stratis.SmartContracts.RuntimeObserver.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RuntimeFrameworkVersion>2.2.7</RuntimeFrameworkVersion>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <Authors>Stratis Group Ltd.</Authors>
+    <Authors>Stratis Group Ltd. and Blockcore Developers</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Added publish release workflow which is initiated by release creation. 
- Fixed bug in pre-release workflow where it was creating tags due to the buildnumber action, this has been replaced with a gist based one. 
- Updated the author and license in the all the projects.
- The required github secrets have already been added to the blockcore repo, but I can't test this until merged