### PR TITLE
Fixed issues caused by the update of Github hosted-runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Update Directory.Build.props for Push
       run: |
-        find . -name 'Directory.Build.props' -print0 | while read -d $'\0' file
+        /usr/bin/find . -name 'Directory.Build.props' -print0 | while read -d $'\0' file
         do
           sed -i 's,</IsPackable>,</IsPackable>\n\t<RepositoryType>git</RepositoryType>\n\t<RepositoryUrl>git://github.com/${{github.repository}}</RepositoryUrl>,g' $file
         done


### PR DESCRIPTION
Without this recent change, the next time we publish, the action will fail, with an error about bash cannot find the correct ‘find’ command.