### PR TITLE
Fix segwit sign message

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Wallet.cs
@@ -344,7 +344,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         public HdAddress GetAddress(string address, Func<HdAccount, bool> accountFilter = null)
         {
             Guard.NotNull(address, nameof(address));
-            return this.GetAllAddresses(accountFilter).SingleOrDefault(a => a.Address == address);
+            return this.GetAllAddresses(accountFilter).SingleOrDefault(a => a.Address == address || a.Bech32Address == address);
         }
     }
 


### PR DESCRIPTION
With this change, the message is successfully signed, but the message is signed with the paired base58 address not the Bech32 address, so in order to validate the message, the user needs to validate from the base58 not the Bech32Address.

Is there a way we can sign with the Bech32 address and not the underlying base58 address?

If there is not a better way, I would suggest that the base58 address is returned with the signature string.