### PR TITLE
Improve coinview cache lock

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/UnspentOutputSet.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/UnspentOutputSet.cs
@@ -47,7 +47,7 @@ namespace Stratis.Bitcoin.Features.Consensus
 
                     if (!unspentOutput.Spend())
                     {
-                        throw new InvalidOperationException("Unspendable coins are invalid at this point");
+                        throw new InvalidOperationException(string.Format("Invalid coin state, UTXO '{0}' is expected to be unspent", unspentOutput.OutPoint));
                     }
                 }
             }
@@ -58,7 +58,7 @@ namespace Stratis.Bitcoin.Features.Consensus
                 var coinbase = transaction.IsCoinBase;
                 var coinstake = network.Consensus.IsProofOfStake ? transaction.IsCoinStake : false;
                 var time = (transaction is IPosTransactionWithTime posTx) ? posTx.Time : 0;
-               
+
                 var coins = new Coins((uint)height, output.TxOut, coinbase, coinstake, time);
                 var unspentOutput = new UnspentOutput(outpoint, coins) 
                 { 

--- a/src/Stratis.Bitcoin/Utilities/UnspentOutput.cs
+++ b/src/Stratis.Bitcoin/Utilities/UnspentOutput.cs
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.Utilities
         /// A flag to mark that the output is new and was created
         /// form the block (and not fetched from disk or from cache).
         /// This is only to be used by the coindb internal logic to indicate
-        /// and output is new and there is no need to try to fetch it form cache.
+        /// an output is new and there is no need to try to fetch it form cache.
         /// </summary>
         public bool CreatedFromBlock { get; set; }
 


### PR DESCRIPTION
Remove the lock when fetching outputs from disk on the cache method:
This method splits the lock in two parts when fetching to not hold the lock when reading from disk.

It still needs to be properly tested (to make sure there are not edge cases issues)
Potentially it needs to introduce a double lock obj, one for the cache and one for the calls to the repo 