### PR TITLE
Move protocol out of the consensus class and in to the consensus factory

### DIFF
--- a/src/Blockcore/BlockPulling/BlockPuller.cs
+++ b/src/Blockcore/BlockPulling/BlockPuller.cs
@@ -225,7 +225,7 @@ namespace Blockcore.BlockPulling
 
             this.networkPeerRequirement = new NetworkPeerRequirement
             {
-                MinVersion = nodeSettings.MinProtocolVersion ?? nodeSettings.Network.Consensus.ConsensusProtocol.ProtocolVersion,
+                MinVersion = nodeSettings.MinProtocolVersion ?? nodeSettings.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion,
                 RequiredServices = NetworkPeerServices.Network
             };
 

--- a/src/Blockcore/Configuration/NodeSettings.cs
+++ b/src/Blockcore/Configuration/NodeSettings.cs
@@ -135,7 +135,7 @@ namespace Blockcore.Configuration
             // Log arguments.
             this.Logger.LogDebug("Arguments: network='{0}', protocolVersion='{1}', agent='{2}', args='{3}'.",
                 this.Network == null ? "(None)" : this.Network.Name,
-                this.Network?.Consensus.ConsensusProtocol.ProtocolVersion,
+                this.Network?.Consensus.ConsensusFactory.Protocol.ProtocolVersion,
                 this.Agent,
                 args == null ? "(None)" : string.Join(" ", args));
 

--- a/src/Blockcore/Connection/ConnectionManager.cs
+++ b/src/Blockcore/Connection/ConnectionManager.cs
@@ -134,7 +134,7 @@ namespace Blockcore.Connection
 
             this.Parameters.UserAgent = $"{this.ConnectionSettings.Agent}:{versionProvider.GetVersion()}";
 
-            this.Parameters.Version = this.NodeSettings.Network.Consensus.ConsensusProtocol.ProtocolVersion;
+            this.Parameters.Version = this.NodeSettings.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion;
 
             nodeStats.RegisterStats(this.AddComponentStats, StatsType.Component, this.GetType().Name, 1100);
         }

--- a/src/Blockcore/Controllers/NodeController.cs
+++ b/src/Blockcore/Controllers/NodeController.cs
@@ -141,7 +141,7 @@ namespace Blockcore.Controllers
             var model = new StatusModel
             {
                 Version = this.fullNode.Version?.ToString() ?? "0",
-                ProtocolVersion = (uint)(this.nodeSettings.Network.Consensus.ConsensusProtocol.ProtocolVersion),
+                ProtocolVersion = (uint)(this.nodeSettings.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion),
                 Difficulty = GetNetworkDifficulty(this.networkDifficulty)?.Difficulty ?? 0,
                 Agent = this.connectionManager.ConnectionSettings.Agent,
                 ExternalAddress = this.selfEndpointTracker.MyExternalAddress.Address.ToString(),

--- a/src/Blockcore/P2P/PeerConnector.cs
+++ b/src/Blockcore/P2P/PeerConnector.cs
@@ -125,7 +125,7 @@ namespace Blockcore.P2P
             this.PeerAddressManager = peerAddressManager;
             this.networkPeerDisposer = new NetworkPeerDisposer(this.loggerFactory, this.asyncProvider, this.OnPeerDisposed);
             this.selfEndpointTracker = selfEndpointTracker;
-            this.Requirements = new NetworkPeerRequirement { MinVersion = nodeSettings.MinProtocolVersion ?? nodeSettings.Network.Consensus.ConsensusProtocol.ProtocolVersion };
+            this.Requirements = new NetworkPeerRequirement { MinVersion = nodeSettings.MinProtocolVersion ?? nodeSettings.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion };
 
             this.connectionInterval = this.CalculateConnectionInterval();
         }

--- a/src/External/NBitcoin/Consensus.cs
+++ b/src/External/NBitcoin/Consensus.cs
@@ -98,12 +98,8 @@ namespace NBitcoin
         /// <inheritdoc />
         public List<Type> MempoolRules { get; set; }
 
-        /// <inheritdoc />
-        public ConsensusProtocol ConsensusProtocol { get; }
-
         public Consensus(
             ConsensusFactory consensusFactory,
-            ConsensusProtocol consensusProtocol,
             ConsensusOptions consensusOptions,
             int coinType,
             uint256 hashGenesisBlock,
@@ -170,11 +166,6 @@ namespace NBitcoin
             this.ConsensusRules = new ConsensusRules();
             this.MempoolRules = new List<Type>();
             this.ProofOfStakeTimestampMask = proofOfStakeTimestampMask;
-            this.ConsensusProtocol = consensusProtocol;
-
-            // this is a small hack to allow acess to protocol verison
-            // form serialization code.
-            this.ConsensusFactory.Protocol = this.ConsensusProtocol;
         }
     }
 }

--- a/src/External/NBitcoin/ConsensusFactory.cs
+++ b/src/External/NBitcoin/ConsensusFactory.cs
@@ -131,7 +131,7 @@ namespace NBitcoin
 
     public class ConsensusProtocol
     {
-        public uint ProtocolVersion { get; set; } = Protocol.ProtocolVersion.WITNESS_VERSION;
+        public uint ProtocolVersion { get; set; } = Protocol.ProtocolVersion.FEEFILTER_VERSION;
 
         public uint MinProtocolVersion { get; set; } = Protocol.ProtocolVersion.SENDHEADERS_VERSION;
     }

--- a/src/External/NBitcoin/IConsensus.cs
+++ b/src/External/NBitcoin/IConsensus.cs
@@ -145,10 +145,5 @@ namespace NBitcoin
 
         /// <summary>Group of mempool validation rules used by the given network.</summary>
         List<Type> MempoolRules { get; set; }
-
-        /// <summary>
-        /// Information about the consensus protocol.
-        /// </summary>
-        ConsensusProtocol ConsensusProtocol { get; }
     }
 }

--- a/src/Features/Blockcore.Features.PoA/PoANetwork.cs
+++ b/src/Features/Blockcore.Features.PoA/PoANetwork.cs
@@ -105,15 +105,14 @@ namespace Blockcore.Features.PoA
 
             var bip9Deployments = new NoBIP9Deployments();
 
-            ConsensusProtocol consensusProtocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new ConsensusProtocol()
             {
-                ProtocolVersion = (uint)ProtocolVersion.PROVEN_HEADER_VERSION,
-                MinProtocolVersion = (uint)ProtocolVersion.POS_PROTOCOL_VERSION,
+                ProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
             };
 
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: consensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: 105,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Features/Blockcore.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Features/Blockcore.Features.RPC/Controllers/FullNodeController.cs
@@ -259,7 +259,7 @@ namespace Blockcore.Features.RPC.Controllers
             var model = new GetInfoModel
             {
                 Version = this.FullNode?.Version?.ToUint() ?? 0,
-                ProtocolVersion = this.Network.Consensus.ConsensusProtocol.ProtocolVersion,
+                ProtocolVersion = this.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion,
                 Blocks = this.ChainState?.ConsensusTip?.Height ?? 0,
                 TimeOffset = this.ConnectionManager?.ConnectedPeers?.GetMedianTimeOffset() ?? 0,
                 Connections = this.ConnectionManager?.ConnectedPeers?.Count(),
@@ -429,7 +429,7 @@ namespace Blockcore.Features.RPC.Controllers
             {
                 Version = this.FullNode?.Version?.ToUint() ?? 0,
                 SubVersion = this.Settings?.Agent,
-                ProtocolVersion = this.Network.Consensus.ConsensusProtocol.ProtocolVersion,
+                ProtocolVersion = this.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion,
                 IsLocalRelay = this.ConnectionManager?.Parameters?.IsRelay ?? false,
                 TimeOffset = this.ConnectionManager?.ConnectedPeers?.GetMedianTimeOffset() ?? 0,
                 Connections = this.ConnectionManager?.ConnectedPeers?.Count(),

--- a/src/Networks/Bitcoin/Blockcore.Networks.Bitcoin/BitcoinMain.cs
+++ b/src/Networks/Bitcoin/Blockcore.Networks.Bitcoin/BitcoinMain.cs
@@ -67,7 +67,7 @@ namespace Blockcore.Networks.Bitcoin
                 [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, 1479168000, 1510704000, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
-            ConsensusProtocol consensusProtocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new ConsensusProtocol()
             {
                 ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
                 MinProtocolVersion = ProtocolVersion.SENDHEADERS_VERSION,
@@ -75,7 +75,6 @@ namespace Blockcore.Networks.Bitcoin
 
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: consensusProtocol,
                 consensusOptions: new ConsensusOptions(), // Default - set to Bitcoin params.
                 coinType: 0,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/Bitcoin/Blockcore.Networks.Bitcoin/BitcoinRegTest.cs
+++ b/src/Networks/Bitcoin/Blockcore.Networks.Bitcoin/BitcoinRegTest.cs
@@ -50,9 +50,14 @@ namespace Blockcore.Networks.Bitcoin
                 [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive)
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.SENDHEADERS_VERSION,
+            };
+
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: new ConsensusOptions(), // Default - set to Bitcoin params.
                 coinType: 0,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/Bitcoin/Blockcore.Networks.Bitcoin/BitcoinTest.cs
+++ b/src/Networks/Bitcoin/Blockcore.Networks.Bitcoin/BitcoinTest.cs
@@ -51,9 +51,14 @@ namespace Blockcore.Networks.Bitcoin
                 [BitcoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, 1462060800, 1493596800, BIP9DeploymentsParameters.DefaultTestnetThreshold)
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.SENDHEADERS_VERSION,
+            };
+
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: new ConsensusOptions(), // Default - set to Bitcoin params.
                 coinType: 1,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/City/City/Networks/CityMain.cs
+++ b/src/Networks/City/City/Networks/CityMain.cs
@@ -82,15 +82,14 @@ namespace City.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            ConsensusProtocol consensusProtocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new ConsensusProtocol()
             {
-                ProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION,
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
                 MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
             };
 
             Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: consensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: setup.CoinType,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/City/City/Networks/CityRegTest.cs
+++ b/src/Networks/City/City/Networks/CityRegTest.cs
@@ -7,6 +7,7 @@ using City.Networks.Setup;
 using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
 
 namespace City.Networks
 {
@@ -64,9 +65,14 @@ namespace City.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+            };
+
             Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: setup.CoinType,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/City/City/Networks/CityTest.cs
+++ b/src/Networks/City/City/Networks/CityTest.cs
@@ -7,6 +7,7 @@ using City.Networks.Setup;
 using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
 
 namespace City.Networks
 {
@@ -64,9 +65,14 @@ namespace City.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+            };
+
             Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: setup.CoinType,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/Stratis/Blockcore.Networks.Stratis/StratisMain.cs
+++ b/src/Networks/Stratis/Blockcore.Networks.Stratis/StratisMain.cs
@@ -112,15 +112,14 @@ namespace Blockcore.Networks.Stratis
                     BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
-            ConsensusProtocol consensusProtocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new ConsensusProtocol()
             {
-                ProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION,
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
                 MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
             };
 
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: consensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: 105,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/Stratis/Blockcore.Networks.Stratis/StratisRegTest.cs
+++ b/src/Networks/Stratis/Blockcore.Networks.Stratis/StratisRegTest.cs
@@ -76,9 +76,14 @@ namespace Blockcore.Networks.Stratis
                 [StratisBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 2, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive),
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+            };
+
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: 105,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/Stratis/Blockcore.Networks.Stratis/StratisTest.cs
+++ b/src/Networks/Stratis/Blockcore.Networks.Stratis/StratisTest.cs
@@ -94,9 +94,14 @@ namespace Blockcore.Networks.Stratis
                     BIP9DeploymentsParameters.DefaultTestnetThreshold)
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+            };
+
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: 105,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/Xds/Blockcore.Networks.Xds/XdsMain.cs
+++ b/src/Networks/Xds/Blockcore.Networks.Xds/XdsMain.cs
@@ -79,15 +79,14 @@ namespace Blockcore.Networks.Xds
                 [XdsBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive)
             };
 
-            ConsensusProtocol consensusProtocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new ConsensusProtocol()
             {
-                ProtocolVersion = (uint)ProtocolVersion.PROVEN_HEADER_VERSION,
-                MinProtocolVersion = (uint)ProtocolVersion.POS_PROTOCOL_VERSION,
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
             };
 
             this.Consensus = new NBitcoin.Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: consensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: (int)this.GenesisNonce,
                 hashGenesisBlock: this.Genesis.GetHash(),

--- a/src/Networks/x42/x42/Networks/Consensus/x42Consensus.cs
+++ b/src/Networks/x42/x42/Networks/Consensus/x42Consensus.cs
@@ -154,12 +154,8 @@ namespace x42.Networks.Consensus
         /// <inheritdoc />
         public Money LastProofOfStakeRewardHeight { get; }
 
-        /// <inheritdoc />
-        public ConsensusProtocol ConsensusProtocol { get; }
-
         public x42Consensus(
             ConsensusFactory consensusFactory,
-            ConsensusProtocol consensusProtocol,
             ConsensusOptions consensusOptions,
             int coinType,
             uint256 hashGenesisBlock,
@@ -233,7 +229,6 @@ namespace x42.Networks.Consensus
             this.MempoolRules = new List<Type>();
             this.PosEmptyCoinbase = posEmptyCoinbase;
             this.ProofOfStakeTimestampMask = proofOfStakeTimestampMask;
-            this.ConsensusProtocol = consensusProtocol;
         }
     }
 }

--- a/src/Networks/x42/x42/Networks/x42Main.cs
+++ b/src/Networks/x42/x42/Networks/x42Main.cs
@@ -88,15 +88,14 @@ namespace x42.Networks
                 [x42BIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, new DateTime(2020, 3, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
-            ConsensusProtocol consensusProtocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new ConsensusProtocol()
             {
-                ProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION,
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
                 MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
             };
 
             this.Consensus = new x42Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: consensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: setup.CoinType,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/x42/x42/Networks/x42RegTest.cs
+++ b/src/Networks/x42/x42/Networks/x42RegTest.cs
@@ -7,6 +7,7 @@ using x42.Networks.Setup;
 using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
 
 namespace x42.Networks
 {
@@ -64,9 +65,14 @@ namespace x42.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+            };
+
             this.Consensus = new x42Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: setup.CoinType,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Networks/x42/x42/Networks/x42Test.cs
+++ b/src/Networks/x42/x42/Networks/x42Test.cs
@@ -7,6 +7,7 @@ using x42.Networks.Setup;
 using NBitcoin;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
 
 namespace x42.Networks
 {
@@ -72,9 +73,14 @@ namespace x42.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
+            consensusFactory.Protocol = new ConsensusProtocol()
+            {
+                ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
+                MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+            };
+
             this.Consensus = new x42Consensus(
                 consensusFactory: consensusFactory,
-                consensusProtocol: this.Consensus.ConsensusProtocol,
                 consensusOptions: consensusOptions,
                 coinType: setup.CoinType,
                 hashGenesisBlock: genesisBlock.GetHash(),

--- a/src/Tests/Blockcore.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
+++ b/src/Tests/Blockcore.Features.RPC.Tests/Controller/FullNodeControllerTest.cs
@@ -493,7 +493,7 @@ namespace Blockcore.Features.RPC.Tests.Controller
                 this.fullNode.Object, this.nodeSettings, this.network, this.chain, this.chainState.Object, this.connectionManager.Object);
             GetInfoModel model = this.controller.GetInfo();
 
-            Assert.Equal(this.Network.Consensus.ConsensusProtocol.ProtocolVersion, model.ProtocolVersion);
+            Assert.Equal(this.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion, model.ProtocolVersion);
             Assert.Equal(0, model.RelayFee);
         }
 

--- a/src/Tests/Blockcore.IntegrationTests/API/ApiSteps.cs
+++ b/src/Tests/Blockcore.IntegrationTests/API/ApiSteps.cs
@@ -482,7 +482,7 @@ namespace Blockcore.IntegrationTests.API
             statusResponse.Network.Should().Be(statusNode.Network.Name);
             statusResponse.ConsensusHeight.Should().Be(0);
             statusResponse.BlockStoreHeight.Should().Be(0);
-            statusResponse.ProtocolVersion.Should().Be((uint)(statusNode.Settings.Network.Consensus.ConsensusProtocol.ProtocolVersion));
+            statusResponse.ProtocolVersion.Should().Be((uint)(statusNode.Settings.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion));
             statusResponse.RelayFee.Should().Be(statusNode.Settings.MinRelayTxFeeRate.FeePerK.ToUnit(MoneyUnit.BTC));
             statusResponse.DataDirectoryPath.Should().Be(statusNode.Settings.DataDir);
 

--- a/src/Tests/Blockcore.IntegrationTests/RPC/GetInfoActionTests.cs
+++ b/src/Tests/Blockcore.IntegrationTests/RPC/GetInfoActionTests.cs
@@ -22,7 +22,7 @@ namespace Blockcore.IntegrationTests.RPC
             GetInfoModel info = controller.GetInfo();
 
             NodeSettings nodeSettings = NodeSettings.Default(fullNode.Network);
-            uint expectedProtocolVersion = fullNode.Network.Consensus.ConsensusProtocol.ProtocolVersion;
+            uint expectedProtocolVersion = fullNode.Network.Consensus.ConsensusFactory.Protocol.ProtocolVersion;
             decimal expectedRelayFee = nodeSettings.MinRelayTxFeeRate.FeePerK.ToUnit(NBitcoin.MoneyUnit.BTC);
             Assert.NotNull(info);
             Assert.Equal(0, info.Blocks);


### PR DESCRIPTION
VersionProtocol is partly used in  determining serialization it makes more sense to keep it in the consensus factory.