### PR TITLE
When segwit address is used to sign, we need to return the address signed with.

### DIFF
--- a/src/Features/Blockcore.Features.BlockStore/Models/SignMessageResult.cs
+++ b/src/Features/Blockcore.Features.BlockStore/Models/SignMessageResult.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Blockcore.Features.BlockStore.Models
+{
+    /// <summary>
+    /// Class containing details of a signature message.
+    /// </summary>
+    public class SignMessageResult
+    {
+        [JsonProperty(PropertyName = "signedAddress")]
+        public string SignedAddress { get; set; }
+
+        [JsonProperty(PropertyName = "signature")]
+        public string Signature { get; set; }
+    }
+}

--- a/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletController.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletController.cs
@@ -7,6 +7,7 @@ using System.Security;
 using System.Text;
 using Blockcore.Connection;
 using Blockcore.Connection.Broadcasting;
+using Blockcore.Features.BlockStore.Models;
 using Blockcore.Features.Wallet.Api.Models;
 using Blockcore.Features.Wallet.Exceptions;
 using Blockcore.Features.Wallet.Interfaces;
@@ -145,7 +146,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
         /// Signs a message and returns the signature.
         /// </summary>
         /// <param name="request">The object containing the parameters used to sign a message.</param>
-        /// <returns>A JSON object containing the generated signature.</returns>
+        /// <returns>A JSON object containing the generated signature and the address used to sign.</returns>
         [Route("signmessage")]
         [HttpPost]
         public IActionResult SignMessage([FromBody]SignMessageRequest request)
@@ -160,7 +161,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
             try
             {
-                string signature = this.walletManager.SignMessage(request.Password, request.WalletName, request.AccountName, request.ExternalAddress, request.Message);
+                SignMessageResult signature = this.walletManager.SignMessage(request.Password, request.WalletName, request.AccountName, request.ExternalAddress, request.Message);
                 return this.Json(signature);
             }
             catch (Exception e)

--- a/src/Features/Blockcore.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Features/Blockcore.Features.Wallet/Interfaces/IWalletManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Blockcore.Features.BlockStore.Models;
 using Blockcore.Features.Wallet.Types;
 using NBitcoin;
 using NBitcoin.BuilderExtensions;
@@ -89,7 +90,7 @@ namespace Blockcore.Features.Wallet.Interfaces
         /// <param name="externalAddress">Address to use to sign.</param>
         /// <param name="message">Message to sign.</param>
         /// <returns>The generated signature.</returns>
-        string SignMessage(string password, string walletName, string accountName, string externalAddress, string message);
+        SignMessageResult SignMessage(string password, string walletName, string accountName, string externalAddress, string message);
 
         /// <summary>
         /// Verifies the signed message.

--- a/src/Features/Blockcore.Features.Wallet/WalletManager.cs
+++ b/src/Features/Blockcore.Features.Wallet/WalletManager.cs
@@ -9,6 +9,7 @@ using Blockcore.AsyncWork;
 using Blockcore.Configuration;
 using Blockcore.Connection.Broadcasting;
 using Blockcore.EventBus;
+using Blockcore.Features.BlockStore.Models;
 using Blockcore.Features.Wallet.Exceptions;
 using Blockcore.Features.Wallet.Helpers;
 using Blockcore.Features.Wallet.Interfaces;
@@ -314,7 +315,7 @@ namespace Blockcore.Features.Wallet
         }
 
         /// <inheritdoc />
-        public string SignMessage(string password, string walletName, string accountName, string externalAddress, string message)
+        public SignMessageResult SignMessage(string password, string walletName, string accountName, string externalAddress, string message)
         {
             Guard.NotEmpty(password, nameof(password));
             Guard.NotEmpty(walletName, nameof(walletName));
@@ -328,7 +329,11 @@ namespace Blockcore.Features.Wallet
             // Sign the message.
             HdAddress hdAddress = wallet.GetAddress(externalAddress, account => account.Name.Equals(accountName));
             Key privateKey = wallet.GetExtendedPrivateKeyForAddress(password, hdAddress).PrivateKey;
-            return privateKey.SignMessage(message);
+            return new SignMessageResult()
+            {
+                Signature = privateKey.SignMessage(message),
+                SignedAddress = hdAddress.Address
+            };
         }
 
         /// <inheritdoc />

--- a/src/Tests/Blockcore.IntegrationTests/Wallet/WalletOperationsTests.cs
+++ b/src/Tests/Blockcore.IntegrationTests/Wallet/WalletOperationsTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Blockcore.Features.BlockStore.Models;
 using Blockcore.Features.Wallet;
 using Blockcore.Features.Wallet.Api.Models;
 using Blockcore.Features.Wallet.Types;
@@ -1493,7 +1494,7 @@ namespace Blockcore.IntegrationTests.Wallet
         public async Task SignMessage()
         {
             // Act.
-            string signatureResult = await $"http://localhost:{this.fixture.Node.ApiPort}/api"
+            SignMessageResult signatureResult = await $"http://localhost:{this.fixture.Node.ApiPort}/api"
                 .AppendPathSegment("wallet/signmessage")
                 .PostJsonAsync(new SignMessageRequest
                 {
@@ -1503,11 +1504,12 @@ namespace Blockcore.IntegrationTests.Wallet
                     Password = this.fixture.walletWithFundsPassword,
                     Message = this.fixture.signatureMessage
                 })
-                .ReceiveJson<string>();
+                .ReceiveJson<SignMessageResult>();
 
             // Assert.
-            signatureResult.Should().Be(this.fixture.validSignature, $"Signature is invalid.");
-            Encoders.Base64.DecodeData(signatureResult).Should().BeOfType<byte[]>($"Signature was not a {typeof(byte[])} type.");
+            signatureResult.SignedAddress.Should().Be(this.fixture.addressWithFunds, $"Returned address is invalid.");
+            signatureResult.Signature.Should().Be(this.fixture.validSignature, $"Signature is invalid.");
+            Encoders.Base64.DecodeData(signatureResult.Signature).Should().BeOfType<byte[]>($"Signature was not a {typeof(byte[])} type.");
         }
 
         [Fact]


### PR DESCRIPTION
This is a follow up to PR https://github.com/block-core/blockcore/pull/66 where I said:

> Is there a way we can sign with the Bech32 address and not the underlying base58 address?
> 
> If there is not a better way, I would suggest that the base58 address is returned with the signature string.

This is the PR for that suggestion as that PR was committed without any further input, so this will provide a solution until a better solution is presented.