### PR TITLE
Allow zero fee's while estimating spendable amount.

### DIFF
--- a/src/Features/Blockcore.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Features/Blockcore.Features.Wallet/WalletTransactionHandler.cs
@@ -160,7 +160,7 @@ namespace Blockcore.Features.Wallet
 
             // Create a recipient with a dummy destination address as it's required by NBitcoin's transaction builder.
             List<Recipient> recipients = new[] { new Recipient { Amount = new Money(maxSpendableAmount), ScriptPubKey = new Key().ScriptPubKey } }.ToList();
-            Money fee;
+            Money fee = Money.Zero;
 
             try
             {
@@ -179,8 +179,11 @@ namespace Blockcore.Features.Wallet
                 this.AddCoins(context);
                 this.AddFee(context);
 
-                // Throw an exception if this code is reached, as building a transaction without any funds for the fee should always throw an exception.
-                throw new WalletException("This should be unreachable; please find and fix the bug that caused this to be reached.");
+                if (this.network.MinTxFee > Money.Zero)
+                {
+                    // Throw an exception if this code is reached, as building a transaction without any funds for the fee should always throw an exception.
+                    throw new WalletException("This should be unreachable; please find and fix the bug that caused this to be reached.");
+                }
             }
             catch (NotEnoughFundsException e)
             {


### PR DESCRIPTION
If the network consensus has no fee's, we need to allow GetMaximumSpendableAmount to continue.