### PR TITLE
Added gettxoutproof RPC

### DIFF
--- a/src/Features/Blockcore.Features.BlockStore/Api/BlockStoreClient.cs
+++ b/src/Features/Blockcore.Features.BlockStore/Api/BlockStoreClient.cs
@@ -4,9 +4,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Blockcore.Controllers;
 using Blockcore.Controllers.Models;
+using Blockcore.Features.BlockStore.Api.Contollers;
+using Blockcore.Features.BlockStore.Api.Models;
 using Microsoft.Extensions.Logging;
 
-namespace Blockcore.Features.BlockStore.Controllers
+namespace Blockcore.Features.BlockStore.Api
 {
     /// <summary>Rest client for <see cref="BlockStoreController"/>.</summary>
     public interface IBlockStoreClient : IRestApiClientBase

--- a/src/Features/Blockcore.Features.BlockStore/Api/Controllers/BlockStoreController.cs
+++ b/src/Features/Blockcore.Features.BlockStore/Api/Controllers/BlockStoreController.cs
@@ -3,6 +3,7 @@ using System.Net;
 using Blockcore.Base;
 using Blockcore.Controllers.Models;
 using Blockcore.Features.BlockStore.AddressIndexing;
+using Blockcore.Features.BlockStore.Api.Models;
 using Blockcore.Features.BlockStore.Models;
 using Blockcore.Interfaces;
 using Blockcore.Utilities;
@@ -12,16 +13,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 
-namespace Blockcore.Features.BlockStore.Controllers
+namespace Blockcore.Features.BlockStore.Api.Contollers
 {
-    public static class BlockStoreRouteEndPoint
-    {
-        public const string GetAddressesBalances = "getaddressesbalances";
-        public const string GetVerboseAddressesBalances = "getverboseaddressesbalances";
-        public const string GetAddressIndexerTip = "addressindexertip";
-        public const string GetBlock = "block";
-        public const string GetBlockCount = "GetBlockCount";
-    }
 
     /// <summary>Controller providing operations on a blockstore.</summary>
     [ApiController]

--- a/src/Features/Blockcore.Features.BlockStore/Api/Controllers/BlockStoreRPCController.cs
+++ b/src/Features/Blockcore.Features.BlockStore/Api/Controllers/BlockStoreRPCController.cs
@@ -1,0 +1,131 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Blockcore.Base;
+using Blockcore.Consensus;
+using Blockcore.Controllers;
+using Blockcore.Controllers.Models;
+using Blockcore.Features.RPC;
+using Blockcore.Features.RPC.Exceptions;
+using Blockcore.Interfaces;
+using Blockcore.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+
+namespace Blockcore.Features.BlockStore.Api.Controllers
+{
+    /// <summary>
+    /// Controller providing RPC operations on a watch-only wallet.
+    /// </summary>
+    public class BlockStoreRPCController : FeatureController
+    {
+        /// <summary>Full Node.</summary>
+        private readonly IFullNode fullNode;
+
+        /// <summary>Thread safe access to the best chain of block headers from genesis.</summary>
+        private readonly ChainIndexer chainIndexer;
+
+        /// <summary>Specification of the network the node runs on.</summary>
+        private readonly Network network;
+
+        /// <summary>Wallet broadcast manager.</summary>
+        private readonly IBroadcasterManager broadcasterManager;
+
+        /// <summary>Instance logger.</summary>
+        private readonly ILogger logger;
+
+        /// <summary>Provides access to the block store database.</summary>
+        private readonly IBlockStore blockStore;
+
+        /// <summary>Information about node's chain.</summary>
+        private readonly IChainState chainState;
+
+        /// <inheritdoc />
+        public BlockStoreRPCController(
+            IFullNode fullNode,
+            IConsensusManager consensusManager,
+            ChainIndexer chainIndexer,
+            Network network,
+            ILoggerFactory loggerFactory,
+            IBlockStore blockStore,
+            IChainState chainState) : base(fullNode: fullNode, consensusManager: consensusManager, chainIndexer: chainIndexer, network: network)
+        {
+            this.fullNode = fullNode;
+            this.chainIndexer = chainIndexer;
+            this.network = network;
+            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
+            this.blockStore = blockStore;
+            this.chainState = chainState;
+        }
+
+        /// <summary>
+        /// By default this function only works when there is an unspent output in the utxo for this transaction.
+        /// To make it work, you need to maintain a transaction index, using the -txindex command line option.
+        /// </summary>
+        /// <param name="txids">The txids to filter</param>
+        /// <param name="blockhash">If specified, looks for txid in the block with this hash</param>
+        /// <returns></returns>
+        [ActionName("gettxoutproof")]
+        [ActionDescription("Checks if transactions are within block. Returns proof of transaction inclusion (raw MerkleBlock).")]
+        public MerkleBlock GetTxOutProof(string[] txids, string blockhash = "")
+        {
+            List<uint256> transactionIds = new List<uint256>();
+            Block block = null;
+            foreach (var txString in txids)
+            {
+                transactionIds.Add(uint256.Parse(txString));
+            }
+
+            if (!string.IsNullOrEmpty(blockhash))
+            {
+                // Loop through txids and veryify that the transaction is in the block.
+                foreach (var transactionId in transactionIds)
+                {
+                    var hashBlock = uint256.Parse(blockhash);
+                    ChainedHeader chainedHeader = this.GetTransactionBlock(transactionId, this.fullNode, this.chainIndexer);
+                    if (chainedHeader.HashBlock != hashBlock)
+                    {
+                        throw new RPCServerException(RPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY, "Not all transactions found in specified or retrieved block");
+                    }
+                    if (block == null && chainedHeader.BlockDataAvailability == BlockDataAvailabilityState.BlockAvailable) // Only get the block once.
+                    {
+                        block = this.blockStore.GetBlock(chainedHeader.HashBlock);
+                    }
+                }
+            }
+            else
+            {
+                // Loop through txids and try to find which block they're in. Exit loop once a block is found.
+                foreach (var transactionId in transactionIds)
+                {
+                    ChainedHeader chainedHeader = this.GetTransactionBlock(transactionId, this.fullNode, this.chainIndexer);
+                    if (chainedHeader.BlockDataAvailability == BlockDataAvailabilityState.BlockAvailable)
+                    {
+                        block = this.blockStore.GetBlock(chainedHeader.HashBlock);
+                        break;
+                    }
+                }
+
+            }
+            if (block == null)
+            {
+                throw new RPCServerException(RPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+            }
+            var result = new MerkleBlock(block, transactionIds.ToArray());
+            return result;
+        }
+
+        internal ChainedHeader GetTransactionBlock(uint256 trxid, IFullNode fullNode, ChainIndexer chain)
+        {
+            Guard.NotNull(fullNode, nameof(fullNode));
+
+            ChainedHeader block = null;
+            uint256 blockid = this.blockStore?.GetBlockIdByTransactionId(trxid);
+            if (blockid != null)
+            {
+                block = chain?.GetHeader(blockid);
+            }
+            return block;
+        }
+    }
+}

--- a/src/Features/Blockcore.Features.BlockStore/Api/Controllers/BlockStoreRPCController.cs
+++ b/src/Features/Blockcore.Features.BlockStore/Api/Controllers/BlockStoreRPCController.cs
@@ -1,16 +1,11 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using Blockcore.Base;
 using Blockcore.Consensus;
 using Blockcore.Controllers;
-using Blockcore.Controllers.Models;
 using Blockcore.Features.RPC;
 using Blockcore.Features.RPC.Exceptions;
 using Blockcore.Interfaces;
 using Blockcore.Primitives;
-using Blockcore.Utilities;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using NBitcoin;
 
 namespace Blockcore.Features.BlockStore.Api.Controllers

--- a/src/Features/Blockcore.Features.BlockStore/Api/Models/BlockStoreRouteEndPoint.cs
+++ b/src/Features/Blockcore.Features.BlockStore/Api/Models/BlockStoreRouteEndPoint.cs
@@ -1,0 +1,11 @@
+﻿namespace Blockcore.Features.BlockStore.Api.Models
+{
+    public static class BlockStoreRouteEndPoint
+    {
+        public const string GetAddressesBalances = "getaddressesbalances";
+        public const string GetVerboseAddressesBalances = "getverboseaddressesbalances";
+        public const string GetAddressIndexerTip = "addressindexertip";
+        public const string GetBlock = "block";
+        public const string GetBlockCount = "GetBlockCount";
+    }
+}

--- a/src/Features/Blockcore.Features.BlockStore/Blockcore.Features.BlockStore.csproj
+++ b/src/Features/Blockcore.Features.BlockStore/Blockcore.Features.BlockStore.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\External\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\..\Blockcore\Blockcore.csproj" />
+    <ProjectReference Include="..\Blockcore.Features.RPC\Blockcore.Features.RPC.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Features/Blockcore.Features.RPC/RPCClient.cs
+++ b/src/Features/Blockcore.Features.RPC/RPCClient.cs
@@ -85,8 +85,8 @@ namespace Blockcore.Features.RPC
         blockchain         getdifficulty
         blockchain         getmempoolinfo
         blockchain         getrawmempool                Yes
-        blockchain         gettxout                    Yes
-        blockchain         gettxoutproof
+        blockchain         gettxout                     Yes
+        blockchain         gettxoutproof                Yes
         blockchain         verifytxoutproof
         blockchain         gettxoutsetinfo
         blockchain         verifychain

--- a/src/Tests/Blockcore.Features.BlockStore.Tests/BlockStoreControllerTests.cs
+++ b/src/Tests/Blockcore.Features.BlockStore.Tests/BlockStoreControllerTests.cs
@@ -3,7 +3,7 @@ using System.Net;
 using Blockcore.Base;
 using Blockcore.Controllers.Models;
 using Blockcore.Features.BlockStore.AddressIndexing;
-using Blockcore.Features.BlockStore.Controllers;
+using Blockcore.Features.BlockStore.Api.Contollers;
 using Blockcore.Features.BlockStore.Models;
 using Blockcore.Interfaces;
 using Blockcore.Tests.Common;


### PR DESCRIPTION
Added `gettxoutproof` RPC (0.20.0 RPC).

Checks if transactions are within block. Returns proof of transaction inclusion (raw MerkleBlock).