### PR TITLE
Make nav menu order configurable

### DIFF
--- a/src/Blockcore/Interfaces/UI/INavigationItem.cs
+++ b/src/Blockcore/Interfaces/UI/INavigationItem.cs
@@ -10,6 +10,7 @@ namespace Blockcore.Interfaces.UI
         public string Navigation { get; }
         public string Icon { get; }
         public bool IsVisible {get; }
+        public int NavOrder {get; }
         
     }
 }

--- a/src/Features/Blockcore.Features.ColdStaking/UI/NavItem.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/UI/NavItem.cs
@@ -17,6 +17,7 @@ namespace Blockcore.Features.Wallet.UI
         public string Navigation => "ColdStaking";
         public string Icon => "oi-pulse";
         public bool IsVisible => this.WalletManager?.ContainsWallets ?? false;
+        public int NavOrder => 30;
 
     }
 }

--- a/src/Features/Blockcore.Features.Miner/UI/NavItem.cs
+++ b/src/Features/Blockcore.Features.Miner/UI/NavItem.cs
@@ -16,5 +16,6 @@ namespace Blockcore.Features.Wallet.UI
         public string Navigation => "Stake";
         public string Icon => "oi-bolt";
         public bool IsVisible => this.WalletManager?.ContainsWallets ?? false;
+        public int NavOrder => 20;
     }
 }

--- a/src/Features/Blockcore.Features.NodeHost/UI/Shared/NavMenu.razor
+++ b/src/Features/Blockcore.Features.NodeHost/UI/Shared/NavMenu.razor
@@ -20,7 +20,7 @@
 
         @{
             var items = fullnode.NodeService<IEnumerable<INavigationItem>>();
-            foreach (var item in items)
+            foreach (var item in items.OrderBy(i => i.NavOrder))
             {
                 if (item.IsVisible) {
                     <li class="nav-item px-3">

--- a/src/Features/Blockcore.Features.Wallet/UI/NavItem.cs
+++ b/src/Features/Blockcore.Features.Wallet/UI/NavItem.cs
@@ -5,9 +5,9 @@ namespace Blockcore.Features.Wallet.UI
     public class WalletNavigationItem : INavigationItem
     {
         public string Name => "Wallets";
-
         public string Navigation => "Wallets";
         public string Icon => "oi-folder";
         public bool IsVisible => true;
+        public int NavOrder => 10;
     }
 }


### PR DESCRIPTION
Added a feature to allow the menu items to be configurable. 

The default order is:

![image](https://user-images.githubusercontent.com/36605607/86511433-15e02300-bdf1-11ea-8e18-21060d2c7544.png)
