### PR TITLE
Add null check to walletsync

### DIFF
--- a/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
@@ -632,7 +632,7 @@ namespace Blockcore.Features.ColdStaking
                 if (script.IsUnspendable)
                 {
                     var data = TxNullDataTemplate.Instance.ExtractScriptPubKeyParameters(script);
-                    if (data.Length == 1)
+                    if (data != null && data.Length == 1)
                     {
                         if (data[0].Length == 40)
                         {


### PR DESCRIPTION
When I was resyncing my wallet I got this exception:

```
Blockcore.AsyncWork.AsyncProvider[0]
      Unhandled exception for async delegate worker WalletSyncManager-blocksQueue.
System.NullReferenceException: Object reference not set to an instance of an object.
   at Blockcore.Features.ColdStaking.ColdStakingManager.ProcessTransaction(Transaction transaction, Nullable`1 blockHeight, Block block, Boolean isPropagated) in C:\source\block-core\blockcore\src\Features\Blockcore.Features.ColdStaking\ColdStakingManager.cs:line 635
   at Blockcore.Features.Wallet.WalletManager.ProcessBlock(Block block, ChainedHeader chainedHeader) in C:\source\block-core\blockcore\src\Features\Blockcore.Features.Wallet\WalletManager.cs:line 1103
   at Blockcore.Features.Wallet.WalletSyncManager.OnProcessBlockAsync(Block block, CancellationToken cancellationToken) in C:\source\block-core\blockcore\src\Features\Blockcore.Features.Wallet\WalletSyncManager.cs:line 240
   at Blockcore.AsyncWork.AsyncQueue`1.ConsumerAsync() in C:\source\block-core\blockcore\src\Blockcore\AsyncWork\AsyncQueue.cs:line 151
```

Looks like ```ExtractScriptPubKeyParameters``` can return null so added null check and wallet was successfully able to sync.