### PR TITLE
Added the Bech32Address to GetAddressBalance()

### DIFF
--- a/src/Features/Blockcore.Features.Wallet/WalletManager.cs
+++ b/src/Features/Blockcore.Features.Wallet/WalletManager.cs
@@ -856,7 +856,7 @@ namespace Blockcore.Features.Wallet
 
                 foreach (Types.Wallet wallet in this.Wallets)
                 {
-                    hdAddress = wallet.GetAllAddresses().FirstOrDefault(a => a.Address == address);
+                    hdAddress = wallet.GetAllAddresses().FirstOrDefault(a => a.Address == address || a.Bech32Address == address);
                     if (hdAddress == null) continue;
 
                     // When this query to get balance on specific address, we will exclude the cold staking UTXOs.


### PR DESCRIPTION
The GetAddressBalance() method does not return any results when using a segwit address. This change fixes this.