### PR TITLE
use rocks without dependency

### DIFF
--- a/src/Blockcore/Blockcore.csproj
+++ b/src/Blockcore/Blockcore.csproj
@@ -49,8 +49,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="LevelDB.Standard" Version="2.1.6.1" />
     <PackageReference Include="NStratis.HashLib" Version="1.0.0.1" />
-    <PackageReference Include="RocksDbNative" Version="6.2.2" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
+    <PackageReference Include="RockDb.Native" Version="6.12.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Features/Blockcore.Features.BlockStore/Blockcore.Features.BlockStore.csproj
+++ b/src/Features/Blockcore.Features.BlockStore/Blockcore.Features.BlockStore.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
-    <PackageReference Include="RocksDbNative" Version="6.2.2" />
+    <PackageReference Include="RockDb.Native" Version="6.12.1" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
   </ItemGroup>
 

--- a/src/Features/Blockcore.Features.Consensus/Blockcore.Features.Consensus.csproj
+++ b/src/Features/Blockcore.Features.Consensus/Blockcore.Features.Consensus.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="LevelDB.Standard" Version="2.1.6.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Microsoft.FASTER" Version="2020.2.1.1" />
-    <PackageReference Include="RocksDbNative" Version="6.2.2" />
+    <PackageReference Include="RockDb.Native" Version="6.12.1" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
   </ItemGroup>
 

--- a/src/Tests/Blockcore.IntegrationTests/Blockcore.IntegrationTests.csproj
+++ b/src/Tests/Blockcore.IntegrationTests/Blockcore.IntegrationTests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="Flurl.Http" Version="2.4.2" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
-    <PackageReference Include="RocksDbNative" Version="6.2.2" />
+    <PackageReference Include="RockDb.Native" Version="6.12.1" />
     <PackageReference Include="RocksDbSharp" Version="6.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Using a version of rocks that does not require the snappy dependency 