### PR TITLE
Add support to retrieve genesis if empty hash is supplied

### DIFF
--- a/src/Blockcore/Consensus/Chain/ChainIndexer.cs
+++ b/src/Blockcore/Consensus/Chain/ChainIndexer.cs
@@ -221,6 +221,12 @@ namespace Blockcore.Consensus.Chain
         {
             lock (this.lockObject)
             {
+                // If node is looking for zero, we'll return the genesis block.
+                if (id == uint256.Zero)
+                {
+                    return this.blocksByHeight[0];
+                }
+
                 ChainedHeader result;
                 this.blocksById.TryGetValue(id, out result);
                 return result;


### PR DESCRIPTION
- This is used by the block indexer in the "blockcore-bitcore" repo.