### PR TITLE
Update coinbase consensus for City Chain

### DIFF
--- a/src/Networks/Blockcore.Networks.City/Networks/CityMain.cs
+++ b/src/Networks/Blockcore.Networks.City/Networks/CityMain.cs
@@ -221,7 +221,7 @@ namespace City.Networks
                 // rules that require the store to be loaded (coinview)
                 .Register<FetchUtxosetRule>()
                 .Register<TransactionDuplicationActivationRule>()
-                .Register<CheckPosUtxosetRule>() // implements BIP68, MaxSigOps and BlockReward calculation
+                .Register<CityCheckPosUtxosetRule>() // implements BIP68, MaxSigOps and BlockReward calculation
                                                  // Place the PosColdStakingRule after the PosCoinviewRule to ensure that all input scripts have been evaluated
                                                  // and that the "IsColdCoinStake" flag would have been set by the OP_CHECKCOLDSTAKEVERIFY opcode if applicable.
                 .Register<PosColdStakingRule>()

--- a/src/Networks/Blockcore.Networks.City/Networks/Rules/CityCheckPosUtxosetRule.cs
+++ b/src/Networks/Blockcore.Networks.City/Networks/Rules/CityCheckPosUtxosetRule.cs
@@ -1,0 +1,41 @@
+﻿using Blockcore.Features.Consensus.Rules.UtxosetRules;
+using NBitcoin;
+
+namespace City.Networks.Rules
+{
+    /// <summary>
+    /// Proof of stake override for the coinview rules - BIP68, MaxSigOps and BlockReward checks.
+    /// The City rule reduces the coinbase reward from 20 to 2 at block height 1 111 111?
+    /// </summary>
+    public class CityCheckPosUtxosetRule : CheckPosUtxosetRule
+    {
+        private static readonly int REDUCTIONHEIGHT = 1111111;
+
+        /// <inheritdoc />
+        public override Money GetProofOfWorkReward(int height)
+        {
+            if (this.IsPremine(height))
+                return this.consensus.PremineReward;
+
+            return this.consensus.ProofOfWorkReward;
+        }
+
+        /// <summary>
+        /// Gets miner's coin stake reward.
+        /// </summary>
+        /// <param name="height">Target block height.</param>
+        /// <returns>Miner's coin stake reward.</returns>
+        public override Money GetProofOfStakeReward(int height)
+        {
+            if (this.IsPremine(height))
+                return this.consensus.PremineReward;
+
+            if (height > REDUCTIONHEIGHT)
+            {
+                return this.consensus.ProofOfStakeReward / 10;
+            }
+
+            return this.consensus.ProofOfStakeReward;
+        }
+    }
+}


### PR DESCRIPTION
- Planned upgrade to the City Chain network with a consensus change that divides the coinbase reward by 10, at block height 1 111 111.