### PR TITLE
Set XDS last POW Block to 165_500

### DIFF
--- a/src/Networks/Blockcore.Networks.Xds/XdsMain.cs
+++ b/src/Networks/Blockcore.Networks.Xds/XdsMain.cs
@@ -119,7 +119,7 @@ namespace Blockcore.Networks.Xds
                 powLimit: new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
                 minimumChainWork: null,
                 isProofOfStake: true,
-                lastPowBlock: 1_000_000_000,
+                lastPowBlock: 165_500,
                 proofOfStakeLimit: new BigInteger(uint256.Parse("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)),
                 proofOfStakeLimitV2: new BigInteger(uint256.Parse("000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffff").ToBytes(false)),
                 proofOfStakeReward: Money.Coins(50),


### PR DESCRIPTION
This is a soft fork change to the XDS consensus rules to make it POS only chain in order to eliminate the pos only exploit 
Currently the chain is at block 165064 so it will kick-in in about 1.5 days. 

This is mandatory upgrade for miners regular clients are not effected only (but should upgrade to be sure to be on the right side of the fork in case pow miners are still trying to miner)

There is a secondary experimental chain currently in testing that will be deployed in a few month to allow back POW in a more strict manner (every POW must be followed by a POS and vise versa)

