### PR TITLE
peer connection failure moved to debug instead of information

### DIFF
--- a/src/Blockcore/Connection/ConnectionManagerBehavior.cs
+++ b/src/Blockcore/Connection/ConnectionManagerBehavior.cs
@@ -85,7 +85,7 @@ namespace Blockcore.Connection
 
                 if ((peer.State == NetworkPeerState.Failed) || (peer.State == NetworkPeerState.Offline))
                 {
-                    this.infoLogger.LogInformation("Peer '{0}' ({1}) offline, reason: '{2}.{3}'", peer.RemoteSocketEndpoint, peer.Inbound ? "inbound" : "outbound", peer.DisconnectReason?.Reason ?? "unknown", peer.DisconnectReason?.Exception?.Message != null ? string.Format(" {0}.", peer.DisconnectReason.Exception.Message) : string.Empty);
+                    this.infoLogger.LogDebug("Peer '{0}' ({1}) offline, reason: '{2}.{3}'", peer.RemoteSocketEndpoint, peer.Inbound ? "inbound" : "outbound", peer.DisconnectReason?.Reason ?? "unknown", peer.DisconnectReason?.Exception?.Message != null ? string.Format(" {0}.", peer.DisconnectReason.Exception.Message) : string.Empty);
 
                     this.connectionManager.RemoveConnectedPeer(peer, "Peer offline");
                 }


### PR DESCRIPTION
peer connection failure is very annoying, it keep spamming "information" log on console
changed its log level to debug instead