### PR TITLE
Update x42 segwit activation

### DIFF
--- a/src/Networks/Blockcore.Networks.x42/Networks/x42Main.cs
+++ b/src/Networks/Blockcore.Networks.x42/Networks/x42Main.cs
@@ -95,7 +95,7 @@ namespace Blockcore.Networks.x42.Networks
             {
                 [x42BIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 27, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold),
                 [x42BIP9Deployments.CSV] = new BIP9DeploymentsParameters("CSV", 0, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold),
-                [x42BIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, new DateTime(2020, 3, 1, 0, 0, 0, DateTimeKind.Utc), new DateTime(2021, 3, 1, 0, 0, 0, DateTimeKind.Utc), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [x42BIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             consensusFactory.Protocol = new ConsensusProtocol()


### PR DESCRIPTION
The activation period passed on the x42 network. We made this change to our clients and did extensive testing and segwit is working when setting this to always active.