### PR TITLE
Allow update of broadcast entry

### DIFF
--- a/src/Blockcore/Connection/Broadcasting/BroadcastTransactionStateChanedEntry.cs
+++ b/src/Blockcore/Connection/Broadcasting/BroadcastTransactionStateChanedEntry.cs
@@ -26,7 +26,7 @@ namespace Blockcore.Connection.Broadcasting
         [JsonConverter(typeof(StringEnumConverter))]
         public TransactionBroadcastState TransactionBroadcastState { get; set; }
 
-        public string ErrorMessage { get; private set; }
+        public string ErrorMessage { get; set; }
 
         public bool CanRespondToGetData { get; set; }
 

--- a/src/Blockcore/Connection/Broadcasting/BroadcasterManager.cs
+++ b/src/Blockcore/Connection/Broadcasting/BroadcasterManager.cs
@@ -60,17 +60,19 @@ namespace Blockcore.Connection.Broadcasting
                 this.Broadcasts.Add(trxHash, broadcastEntry);
                 changed = true;
             }
-
-            if (broadcastEntry.TransactionBroadcastState != transactionBroadcastState)
+            else
             {
-                broadcastEntry.TransactionBroadcastState = transactionBroadcastState;
-                changed = true;
-            }
+                if (broadcastEntry.TransactionBroadcastState != transactionBroadcastState)
+                {
+                    broadcastEntry.TransactionBroadcastState = transactionBroadcastState;
+                    changed = true;
+                }
 
-            if (broadcastEntry.ErrorMessage != errorMessage)
-            {
-                broadcastEntry.ErrorMessage = errorMessage;
-                changed = true;
+                if (broadcastEntry.ErrorMessage != errorMessage)
+                {
+                    broadcastEntry.ErrorMessage = errorMessage;
+                    changed = true;
+                }
             }
 
             if (changed)

--- a/src/Blockcore/Connection/Broadcasting/BroadcasterManager.cs
+++ b/src/Blockcore/Connection/Broadcasting/BroadcasterManager.cs
@@ -50,6 +50,7 @@ namespace Blockcore.Connection.Broadcasting
         /// <summary>Adds or updates a transaction from the collection of transactions to broadcast.</summary>
         public void AddOrUpdate(Transaction transaction, TransactionBroadcastState transactionBroadcastState, string errorMessage = null)
         {
+            bool changed = false;
             uint256 trxHash = transaction.GetHash();
             BroadcastTransactionStateChanedEntry broadcastEntry = this.Broadcasts.TryGet(trxHash);
 
@@ -57,11 +58,23 @@ namespace Blockcore.Connection.Broadcasting
             {
                 broadcastEntry = new BroadcastTransactionStateChanedEntry(transaction, transactionBroadcastState, errorMessage);
                 this.Broadcasts.Add(trxHash, broadcastEntry);
-                this.OnTransactionStateChanged(broadcastEntry);
+                changed = true;
             }
-            else if (broadcastEntry.TransactionBroadcastState != transactionBroadcastState)
+
+            if (broadcastEntry.TransactionBroadcastState != transactionBroadcastState)
             {
                 broadcastEntry.TransactionBroadcastState = transactionBroadcastState;
+                changed = true;
+            }
+
+            if (broadcastEntry.ErrorMessage != errorMessage)
+            {
+                broadcastEntry.ErrorMessage = errorMessage;
+                changed = true;
+            }
+
+            if (changed)
+            {
                 this.OnTransactionStateChanged(broadcastEntry);
             }
         }


### PR DESCRIPTION
- There might be multiple issues with a transaction and if sent multiple times with different errors, the error did not update.
- Closes #312