### PR TITLE
Added optional fee and segwit parameters to RPC

### DIFF
--- a/src/Features/Blockcore.Features.RPC/RPCClient.cs
+++ b/src/Features/Blockcore.Features.RPC/RPCClient.cs
@@ -1424,14 +1424,18 @@ namespace Blockcore.Features.RPC
             var parameters = new List<object>();
             parameters.Add(address.ToString());
             parameters.Add(amount.ToString());
-            parameters.Add(fee.ToString());
-            parameters.Add(isSegwit.ToString());
-
+            
             if (commentTx != null)
                 parameters.Add(commentTx);
 
             if (commentDest != null)
                 parameters.Add(commentDest);
+
+            if (fee > 0)
+                parameters.Add(fee.ToString());
+
+            if (isSegwit)
+                parameters.Add(isSegwit.ToString());
 
             RPCResponse resp = await SendCommandAsync(RPCOperations.sendtoaddress, parameters.ToArray()).ConfigureAwait(false);
             return uint256.Parse(resp.Result.ToString());

--- a/src/Features/Blockcore.Features.RPC/RPCClient.cs
+++ b/src/Features/Blockcore.Features.RPC/RPCClient.cs
@@ -1403,7 +1403,7 @@ namespace Blockcore.Features.RPC
         /// <param name="commentTx">A locally-stored (not broadcast) comment assigned to this transaction. Default is no comment</param>
         /// <param name="commentDest">A locally-stored (not broadcast) comment assigned to this transaction. Meant to be used for describing who the payment was sent to. Default is no comment</param>
         /// <returns>The TXID of the sent transaction</returns>
-        public uint256 SendToAddress(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal fee = 0, bool isSegwit = false)
+        public uint256 SendToAddress(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal? fee = null, bool isSegwit = false)
         {
             uint256 txid = null;
 
@@ -1419,19 +1419,19 @@ namespace Blockcore.Features.RPC
         /// <param name="commentTx">A locally-stored (not broadcast) comment assigned to this transaction. Default is no comment</param>
         /// <param name="commentDest">A locally-stored (not broadcast) comment assigned to this transaction. Meant to be used for describing who the payment was sent to. Default is no comment</param>
         /// <returns>The TXID of the sent transaction</returns>
-        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal fee = 0, bool isSegwit = false)
+        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal? fee = null, bool isSegwit = false)
         {
             var parameters = new List<object>();
             parameters.Add(address.ToString());
             parameters.Add(amount.ToString());
-            
+
             if (commentTx != null)
                 parameters.Add(commentTx);
 
             if (commentDest != null)
                 parameters.Add(commentDest);
 
-            if (fee > 0)
+            if (fee != null)
                 parameters.Add(fee.ToString());
 
             if (isSegwit)

--- a/src/Features/Blockcore.Features.RPC/RPCClient.cs
+++ b/src/Features/Blockcore.Features.RPC/RPCClient.cs
@@ -161,7 +161,7 @@ namespace Blockcore.Features.RPC
         wallet             move
         wallet             sendfrom
         wallet             sendmany
-        wallet             sendtoaddress
+        wallet             sendtoaddress                Yes
         wallet             setaccount
         wallet             settxfee
         wallet             signmessage
@@ -382,7 +382,7 @@ namespace Blockcore.Features.RPC
             catch (NotImplementedException)
             {
             }
-  
+
             if (address == null)
             {
                 setResult(false);
@@ -1403,11 +1403,11 @@ namespace Blockcore.Features.RPC
         /// <param name="commentTx">A locally-stored (not broadcast) comment assigned to this transaction. Default is no comment</param>
         /// <param name="commentDest">A locally-stored (not broadcast) comment assigned to this transaction. Meant to be used for describing who the payment was sent to. Default is no comment</param>
         /// <returns>The TXID of the sent transaction</returns>
-        public uint256 SendToAddress(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null)
+        public uint256 SendToAddress(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal fee = 0, bool isSegwit = false)
         {
             uint256 txid = null;
 
-            txid = SendToAddressAsync(address, amount, commentTx, commentDest).GetAwaiter().GetResult();
+            txid = SendToAddressAsync(address, amount, commentTx, commentDest, fee, isSegwit).GetAwaiter().GetResult();
             return txid;
         }
 
@@ -1419,11 +1419,13 @@ namespace Blockcore.Features.RPC
         /// <param name="commentTx">A locally-stored (not broadcast) comment assigned to this transaction. Default is no comment</param>
         /// <param name="commentDest">A locally-stored (not broadcast) comment assigned to this transaction. Meant to be used for describing who the payment was sent to. Default is no comment</param>
         /// <returns>The TXID of the sent transaction</returns>
-        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null)
+        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal fee = 0, bool isSegwit = false)
         {
             var parameters = new List<object>();
             parameters.Add(address.ToString());
             parameters.Add(amount.ToString());
+            parameters.Add(fee.ToString());
+            parameters.Add(isSegwit.ToString());
 
             if (commentTx != null)
                 parameters.Add(commentTx);

--- a/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletRPCController.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletRPCController.cs
@@ -120,19 +120,16 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
         [ActionName("sendtoaddress")]
         [ActionDescription("Sends money to an address. Requires wallet to be unlocked using walletpassphrase.")]
-        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, decimal amount, string commentTx, string commentDest, decimal fee = 0, bool isSegwit = false)
+        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, decimal amount, string commentTx, string commentDest, decimal? fee = null, bool isSegwit = false)
         {
-            if (fee <= 0)
-            {
-                fee = this.FullNode.Network.MinTxFee;
-            }
+            decimal transactionFee = fee ?? this.FullNode.Network.MinTxFee;
 
             TransactionBuildContext context = new TransactionBuildContext(this.FullNode.Network)
             {
                 AccountReference = this.GetWalletAccountReference(),
                 Recipients = new[] { new Recipient { Amount = Money.Coins(amount), ScriptPubKey = address.ScriptPubKey } }.ToList(),
                 CacheSecret = false,
-                TransactionFee = Money.Coins(fee),
+                TransactionFee = Money.Coins(transactionFee),
                 UseSegwitChangeAddress = isSegwit
             };
 

--- a/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletRPCController.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletRPCController.cs
@@ -122,7 +122,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
         [ActionDescription("Sends money to an address. Requires wallet to be unlocked using walletpassphrase.")]
         public async Task<uint256> SendToAddressAsync(BitcoinAddress address, decimal amount, string commentTx, string commentDest, decimal? fee = null, bool isSegwit = false)
         {
-            decimal transactionFee = fee ?? this.FullNode.Network.MinTxFee;
+            decimal transactionFee = fee ?? Money.Satoshis(this.FullNode.Network.MinTxFee).ToDecimal(MoneyUnit.BTC);
 
             TransactionBuildContext context = new TransactionBuildContext(this.FullNode.Network)
             {

--- a/src/Tests/Blockcore.IntegrationTests/API/ApiSteps.cs
+++ b/src/Tests/Blockcore.IntegrationTests/API/ApiSteps.cs
@@ -458,7 +458,7 @@ namespace Blockcore.IntegrationTests.API
             commands.Should().Contain(x => x.Command == "walletpassphrase <passphrase> <timeout>");
             commands.Should().Contain(x => x.Command == "walletlock");
             commands.Should().Contain(x => x.Command == "getwalletinfo");
-            commands.Should().Contain(x => x.Command == "sendtoaddress <address> <amount> <commenttx> <commentdest>");
+            commands.Should().Contain(x => x.Command == "sendtoaddress <address> <amount> <commenttx> <commentdest> [<fee>] [<issegwit>]");
             commands.Should().Contain(x => x.Command == "sendrawtransaction <hex>");
             commands.Should().Contain(x => x.Command == "getnewaddress [<account>] [<addresstype>]");
             commands.Should().Contain(x => x.Command == "getunusedaddress <account> <addresstype>");

--- a/src/Tests/Blockcore.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Tests/Blockcore.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -134,7 +134,7 @@ namespace Blockcore.IntegrationTests.RPC
                 var alice = new Key().GetBitcoinSecret(network);
                 var aliceAddress = alice.GetAddress();
                 rpcClient.WalletPassphrase("password", 60);
-                var txid = rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m));
+                var txid = rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
                 rpcClient.SendCommand(RPCOperations.walletlock);
 
                 // Check the hash calculated correctly.
@@ -159,19 +159,19 @@ namespace Blockcore.IntegrationTests.RPC
                 RPCClient rpcClient = node.CreateRPCClient();
 
                 // Not unlocked case.
-                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m));
+                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
 
                 // Unlock and lock case.
                 rpcClient.WalletPassphrase("password", 60);
                 rpcClient.SendCommand(RPCOperations.walletlock);
-                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m));
+                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
 
                 // Unlock timesout case.
                 rpcClient.WalletPassphrase("password", 5);
                 Thread.Sleep(10 * 1000); // 10 seconds.
-                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m));
+                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
             }
         }
@@ -294,17 +294,17 @@ namespace Blockcore.IntegrationTests.RPC
                 rpcClient.WalletPassphrase("password", 20);
 
                 // Send a transaction.
-                rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m)).Should().NotBeNull();
+                rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false).Should().NotBeNull();
 
                 // Wait 10 seconds and then send another transaction, should still be unlocked.
                 Thread.Sleep(10 * 1000);
 
                 var bobAddress = new Key().GetBitcoinSecret(network).GetAddress();
-                rpcClient.SendToAddress(bobAddress, Money.Coins(1.0m)).Should().NotBeNull();
+                rpcClient.SendToAddress(bobAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false).Should().NotBeNull();
 
                 // Now wait 10 seconds so the wallet should be back locked and a transaction should fail.
                 Thread.Sleep(10 * 1000);
-                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m));
+                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
             }
         }


### PR DESCRIPTION
There should be a better way to determine the fee of the network but until then, I've added this so chains like XDS that have custom fee of `AbsoluteMinimum` consensus so a custom fee can be passed in the RPC.