### PR TITLE
Add witness service always

### DIFF
--- a/src/Blockcore/Consensus/BlockInfo/Block.cs
+++ b/src/Blockcore/Consensus/BlockInfo/Block.cs
@@ -93,33 +93,31 @@ namespace Blockcore.Consensus.BlockInfo
             if (this.Transactions.Count == 0)
                 return this;
 
-            // If the peer does not support witness, then strip it off.
-            if (options == TransactionOptions.None && this.Transactions[0].HasWitness)
-            {
-                Block instance = consensusFactory.CreateBlock();
-                using (var ms = new MemoryStream())
-                {
-                    var bms = new BitcoinStream(ms, true, consensusFactory)
-                    {
-                        TransactionOptions = options,
-                    };
-
-                    this.ReadWrite(bms);
-                    ms.Position = 0;
-                    bms = new BitcoinStream(ms, false, consensusFactory)
-                    {
-                        TransactionOptions = options,
-                    };
-
-                    instance.ReadWrite(bms);
-                }
-
-                return instance;
-            }
-            else
-            {
+            if ((options == TransactionOptions.Witness))
                 return this;
+
+            if ((options == TransactionOptions.None) && !this.Transactions[0].HasWitness)
+                return this;
+
+            Block instance = consensusFactory.CreateBlock();
+            using (var ms = new MemoryStream())
+            {
+                var bms = new BitcoinStream(ms, true, consensusFactory)
+                {
+                    TransactionOptions = options,
+                };
+
+                this.ReadWrite(bms);
+                ms.Position = 0;
+                bms = new BitcoinStream(ms, false, consensusFactory)
+                {
+                    TransactionOptions = options,
+                };
+
+                instance.ReadWrite(bms);
             }
+
+            return instance;
         }
 
         public void UpdateMerkleRoot()

--- a/src/Blockcore/Consensus/BlockInfo/Block.cs
+++ b/src/Blockcore/Consensus/BlockInfo/Block.cs
@@ -90,34 +90,33 @@ namespace Blockcore.Consensus.BlockInfo
         /// <returns>A new block with only the options wanted.</returns>
         public Block WithOptions(ConsensusFactory consensusFactory, TransactionOptions options)
         {
-            if (this.Transactions.Count == 0)
-                return this;
-
-            if ((options == TransactionOptions.Witness))
-                return this;
-
-            if ((options == TransactionOptions.None) && !this.Transactions[0].HasWitness)
-                return this;
-
-            Block instance = consensusFactory.CreateBlock();
-            using (var ms = new MemoryStream())
+            // If the peer does not support witness, then strip it off.
+            if (this.Transactions.Count > 0 && this.Transactions[0].HasWitness && options == TransactionOptions.None)
             {
-                var bms = new BitcoinStream(ms, true, consensusFactory)
+                Block instance = consensusFactory.CreateBlock();
+                using (var ms = new MemoryStream())
                 {
-                    TransactionOptions = options,
-                };
+                    var bms = new BitcoinStream(ms, true, consensusFactory)
+                    {
+                        TransactionOptions = options,
+                    };
 
-                this.ReadWrite(bms);
-                ms.Position = 0;
-                bms = new BitcoinStream(ms, false, consensusFactory)
-                {
-                    TransactionOptions = options,
-                };
+                    this.ReadWrite(bms);
+                    ms.Position = 0;
+                    bms = new BitcoinStream(ms, false, consensusFactory)
+                    {
+                        TransactionOptions = options,
+                    };
 
-                instance.ReadWrite(bms);
+                    instance.ReadWrite(bms);
+                }
+
+                return instance;
             }
-
-            return instance;
+            else
+            {
+                return this;
+            }
         }
 
         public void UpdateMerkleRoot()

--- a/src/Features/Blockcore.Features.Consensus/ConsensusFeature.cs
+++ b/src/Features/Blockcore.Features.Consensus/ConsensusFeature.cs
@@ -56,10 +56,10 @@ namespace Blockcore.Features.Consensus
             {
                 // Add witness discovery as a requirement if witness is activated.
                 this.connectionManager.AddDiscoveredNodesRequirement(NetworkPeerServices.NODE_WITNESS);
-
-                // Set witness as a supported service if witness is activated.
-                this.connectionManager.Parameters.Services |= NetworkPeerServices.NODE_WITNESS;
             }
+
+            // Always announce that the node supports WITNESS even if witness is not activated yet.
+            this.connectionManager.Parameters.Services |= NetworkPeerServices.NODE_WITNESS;
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
- Add the witness service on startup to the node.
- Refactor the "WithOptions" method to clearly state conditions for logic.
- Closes #320