### PR TITLE
XRC: Add missing HeaderVersionRule

### DIFF
--- a/src/Networks/Blockcore.Networks.XRC/Rules/XRCHeaderVersionRule.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Rules/XRCHeaderVersionRule.cs
@@ -1,0 +1,16 @@
+using Blockcore.Consensus.Rules;
+using Blockcore.Features.Consensus.Rules.CommonRules;
+
+namespace Blockcore.Networks.XRC.Rules
+{
+    /// <summary>
+    /// Checks if <see cref="XRCMain"/> network block's header has a valid block version.
+    /// </summary>
+    public class XRCHeaderVersionRule : HeaderVersionRule
+    {
+        /// <inheritdoc />
+        public override void Run(RuleContext context)
+        {
+        }
+    }
+}

--- a/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
@@ -9,6 +9,7 @@ using Blockcore.Consensus.TransactionInfo;
 using Blockcore.Features.Consensus.Rules.CommonRules;
 using Blockcore.Features.Consensus.Rules.UtxosetRules;
 using Blockcore.Features.MemoryPool.Rules;
+using Blockcore.Networks.XRC.Rules;
 using Blockcore.Networks.XRC.Consensus;
 using Blockcore.Networks.XRC.Deployments;
 using Blockcore.Networks.XRC.Policies;
@@ -16,7 +17,6 @@ using Blockcore.P2P;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
-using Blockcore.Networks.XRC.Rules;
 
 namespace Blockcore.Networks.XRC
 {
@@ -189,8 +189,9 @@ namespace Blockcore.Networks.XRC
         protected void RegisterRules(IConsensus consensus)
         {
             consensus.ConsensusRules
-                .Register<HeaderTimeChecksRule>() 
-                .Register<XRCCheckDifficultyPowRule>(); 
+                .Register<HeaderTimeChecksRule>()
+                .Register<XRCCheckDifficultyPowRule>()
+                .Register<XRCHeaderVersionRule>();
 
             consensus.ConsensusRules
                 .Register<BlockMerkleRootRule>(); 


### PR DESCRIPTION
For the XRC integration, a HeaderVersionRule was missing and thus couldn't be used to mine blocks.

This adds a HeaderVersionRule, doing the same thing that Bitcoin version does for now.