### PR TITLE
Remove the ChainedBlocksDataBytes

### DIFF
--- a/src/Blockcore/Consensus/Chain/ChainedHeaderTree.cs
+++ b/src/Blockcore/Consensus/Chain/ChainedHeaderTree.cs
@@ -46,9 +46,6 @@ namespace Blockcore.Consensus.Chain
         /// <summary>Total amount of unconsumed blocks.</summary>
         long UnconsumedBlocksCount { get; }
 
-        /// <summary>Total size of ChainedHeaders data in bytes.</summary>
-        long ChainedBlocksDataBytes { get; }
-
         /// <summary>
         /// Initialize the tree with consensus tip.
         /// </summary>
@@ -183,9 +180,6 @@ namespace Blockcore.Consensus.Chain
         /// <inheritdoc />
         public long UnconsumedBlocksCount { get; private set; }
 
-        /// <inheritdoc />
-        public long ChainedBlocksDataBytes { get; private set; }
-
         /// <summary>A special peer identifier that represents our local node.</summary>
         internal const int LocalPeerId = -1;
 
@@ -252,7 +246,6 @@ namespace Blockcore.Consensus.Chain
             {
                 current.Previous.Next.Add(current);
                 this.chainedHeadersByHash.Add(current.HashBlock, current);
-                this.ChainedBlocksDataBytes += current.Header.HeaderSize;
 
                 // TODO when pruned node is implemented it should be header only for pruned blocks
                 current.BlockDataAvailability = BlockDataAvailabilityState.BlockAvailable;
@@ -263,7 +256,6 @@ namespace Blockcore.Consensus.Chain
 
             // Add the genesis block.
             this.chainedHeadersByHash.Add(current.HashBlock, current);
-            this.ChainedBlocksDataBytes += current.Header.HeaderSize;
 
             if (current.HashBlock != this.network.GenesisHash)
             {
@@ -607,7 +599,6 @@ namespace Blockcore.Consensus.Chain
         {
             header.Previous.Next.Remove(header);
             this.chainedHeadersByHash.Remove(header.HashBlock);
-            this.ChainedBlocksDataBytes -= header.Header.HeaderSize;
 
             if (header.Block != null)
             {
@@ -1106,7 +1097,6 @@ namespace Blockcore.Consensus.Chain
 
             previousChainedHeader.Next.Add(newChainedHeader);
             this.chainedHeadersByHash.Add(newChainedHeader.HashBlock, newChainedHeader);
-            this.ChainedBlocksDataBytes += newChainedHeader.Header.HeaderSize;
 
             return newChainedHeader;
         }

--- a/src/Blockcore/Consensus/ConsensusManager.cs
+++ b/src/Blockcore/Consensus/ConsensusManager.cs
@@ -1459,8 +1459,6 @@ namespace Blockcore.Consensus
                 log.AppendLine($"Tip Age: { TimeSpan.FromSeconds(tipAge).ToString(@"dd\.hh\:mm\:ss") } (maximum is { TimeSpan.FromSeconds(maxTipAge).ToString(@"dd\.hh\:mm\:ss") })");
                 log.AppendLine($"In IBD Stage: { (this.isIbd ? "Yes" : "No") }");
 
-                log.AppendLine($"Chained header tree size: {this.chainedHeaderTree.ChainedBlocksDataBytes.BytesToMegaBytes()} MB");
-
                 string unconsumedBlocks = this.FormatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
 
                 double filledPercentage = Math.Round((this.chainedHeaderTree.UnconsumedBlocksDataBytes / (double)this.maxUnconsumedBlocksDataBytes) * 100, 2);


### PR DESCRIPTION
- "ChainedBlocksDataBytes" was not really used, but required loading of all headers on startup. Removed to improve performance from 52 seconds to 42 seconds.
- This was discovered independent of https://github.com/stratisproject/StratisFullNode/pull/233, but linking to that issue to help Stratis and Blockcore-based blockchains to take the improvement.
- #337