### PR TITLE
Use iterator for chained header loading

### DIFF
--- a/src/Blockcore/Consensus/Chain/ChainRepository.cs
+++ b/src/Blockcore/Consensus/Chain/ChainRepository.cs
@@ -62,17 +62,17 @@ namespace Blockcore.Consensus.Chain
 
                     Guard.Assert(data.Hash == genesisHeader.HashBlock); // can't swap networks
 
-                    int index = 0;
-                    while (true)
+                    var list = this.chainStore.GetChainData();
+
+                    foreach (var chainedData in list)
                     {
-                        data = this.chainStore.GetChainData((index));
+                        // Create a new ChainedHeader with reference to previous. This will build a large object graph of all headers.
+                        tip = new ChainedHeader(chainedData.Hash, chainedData.Work, tip);
 
-                        if (data == null)
-                            break;
-
-                        tip = new ChainedHeader(data.Hash, data.Work, tip);
-                        if (tip.Height == 0) tip.SetChainStore(this.chainStore);
-                        index++;
+                        if (tip.Height == 0)
+                        {
+                            tip.SetChainStore(this.chainStore);
+                        }
                     }
 
                     if (tip == null)

--- a/src/Blockcore/Consensus/Chain/ChainStore.cs
+++ b/src/Blockcore/Consensus/Chain/ChainStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Blockcore.Consensus.BlockInfo;
 using NBitcoin;
 
@@ -11,6 +12,8 @@ namespace Blockcore.Consensus.Chain
         BlockHeader GetHeader(ChainedHeader chainedHeader, uint256 hash);
 
         bool PutHeader(BlockHeader blockHeader);
+
+        IEnumerable<ChainData> GetChainData();
 
         ChainData GetChainData(int height);
 
@@ -76,6 +79,12 @@ namespace Blockcore.Consensus.Chain
         public bool PutHeader(BlockHeader blockHeader)
         {
             return this.headers.TryAdd(blockHeader.GetHash(), blockHeader);
+        }
+
+        public IEnumerable<ChainData> GetChainData()
+        {
+            // Order by height and return new array with ChainData.
+            return this.chainData.OrderBy(c => c.Key).Select(c => c.Value);
         }
 
         public ChainData GetChainData(int height)


### PR DESCRIPTION
- This is a small improvement on the performance, there are alternative ways to do this than using Dictionary, which is a little bit faster still. This is the cleanest example, please suggest and try out improvements.
- Only the LevelDB implementation has been verified.
- #337