### PR TITLE
Cache the deployment flags to improve startup

### DIFF
--- a/src/Features/Blockcore.Features.Consensus/PosConsensusFeature.cs
+++ b/src/Features/Blockcore.Features.Consensus/PosConsensusFeature.cs
@@ -15,6 +15,7 @@ using Blockcore.Interfaces;
 using Blockcore.Networks;
 using Blockcore.P2P.Peer;
 using Blockcore.Signals;
+using Blockcore.Utilities.Store;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 
@@ -51,7 +52,9 @@ namespace Blockcore.Features.Consensus
             ILoggerFactory loggerFactory,
             ICheckpoints checkpoints,
             IProvenBlockHeaderStore provenBlockHeaderStore,
-            ConnectionManagerSettings connectionManagerSettings) : base(network, chainState, connectionManager, signals, consensusManager, nodeDeployments)
+            ConnectionManagerSettings connectionManagerSettings,
+            IKeyValueRepository keyValueRepository
+            ) : base(network, chainState, connectionManager, signals, consensusManager, nodeDeployments, keyValueRepository)
         {
             this.network = network;
             this.chainState = chainState;

--- a/src/Features/Blockcore.Features.Consensus/PowConsensusFeature.cs
+++ b/src/Features/Blockcore.Features.Consensus/PowConsensusFeature.cs
@@ -9,6 +9,7 @@ using Blockcore.Consensus.Chain;
 using Blockcore.Interfaces;
 using Blockcore.Networks;
 using Blockcore.Signals;
+using Blockcore.Utilities.Store;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 
@@ -38,7 +39,8 @@ namespace Blockcore.Features.Consensus
             IInitialBlockDownloadState initialBlockDownloadState,
             IPeerBanning peerBanning,
             ISignals signals,
-            ILoggerFactory loggerFactory) : base(network, chainState, connectionManager, signals, consensusManager, nodeDeployments)
+            ILoggerFactory loggerFactory,
+            IKeyValueRepository keyValueRepository) : base(network, chainState, connectionManager, signals, consensusManager, nodeDeployments, keyValueRepository)
         {
             this.chainState = chainState;
             this.connectionManager = connectionManager;

--- a/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
+++ b/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
@@ -1,17 +1,28 @@
 ﻿using System.Threading.Tasks;
 using Blockcore.Consensus.Rules;
+using Blockcore.Utilities.Store;
 
 namespace Blockcore.Features.Consensus.Rules.CommonRules
 {
     /// <summary>Set the <see cref="RuleContext.Flags"/> property that defines what deployments have been activated.</summary>
     public class SetActivationDeploymentsPartialValidationRule : PartialValidationConsensusRule
     {
+        private readonly IKeyValueRepository keyValueRepository;
+
+        public SetActivationDeploymentsPartialValidationRule(IKeyValueRepository keyValueRepository)
+        {
+            this.keyValueRepository = keyValueRepository;
+        }
+
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.InvalidPrevTip">The tip is invalid because a reorg has been detected.</exception>
         public override Task RunAsync(RuleContext context)
         {
             // Calculate the consensus flags and check they are valid.
             context.Flags = this.Parent.NodeDeployments.GetFlags(context.ValidationContext.ChainedHeaderToValidate);
+
+            // Update the cache of Flags when we retrieve it.
+            this.keyValueRepository.SaveValueJson("deploymentflags", context.Flags);
 
             return Task.CompletedTask;
         }

--- a/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
+++ b/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
@@ -9,6 +9,11 @@ namespace Blockcore.Features.Consensus.Rules.CommonRules
     {
         private readonly IKeyValueRepository keyValueRepository;
 
+        public SetActivationDeploymentsPartialValidationRule()
+        {
+
+        }
+
         public SetActivationDeploymentsPartialValidationRule(IKeyValueRepository keyValueRepository)
         {
             this.keyValueRepository = keyValueRepository;

--- a/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
+++ b/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
@@ -26,8 +26,11 @@ namespace Blockcore.Features.Consensus.Rules.CommonRules
             // Calculate the consensus flags and check they are valid.
             context.Flags = this.Parent.NodeDeployments.GetFlags(context.ValidationContext.ChainedHeaderToValidate);
 
-            // Update the cache of Flags when we retrieve it.
-            this.keyValueRepository.SaveValueJson("deploymentflags", context.Flags);
+            if (this.keyValueRepository != null)
+            {
+                // Update the cache of Flags when we retrieve it.
+                this.keyValueRepository.SaveValueJson("deploymentflags", context.Flags);
+            }
 
             return Task.CompletedTask;
         }

--- a/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
+++ b/src/Features/Blockcore.Features.Consensus/Rules/CommonRules/SetActivationDeploymentsPartialValidationRule.cs
@@ -1,36 +1,17 @@
 ﻿using System.Threading.Tasks;
 using Blockcore.Consensus.Rules;
-using Blockcore.Utilities.Store;
 
 namespace Blockcore.Features.Consensus.Rules.CommonRules
 {
     /// <summary>Set the <see cref="RuleContext.Flags"/> property that defines what deployments have been activated.</summary>
     public class SetActivationDeploymentsPartialValidationRule : PartialValidationConsensusRule
     {
-        private readonly IKeyValueRepository keyValueRepository;
-
-        public SetActivationDeploymentsPartialValidationRule()
-        {
-
-        }
-
-        public SetActivationDeploymentsPartialValidationRule(IKeyValueRepository keyValueRepository)
-        {
-            this.keyValueRepository = keyValueRepository;
-        }
-
         /// <inheritdoc />
         /// <exception cref="ConsensusErrors.InvalidPrevTip">The tip is invalid because a reorg has been detected.</exception>
         public override Task RunAsync(RuleContext context)
         {
             // Calculate the consensus flags and check they are valid.
             context.Flags = this.Parent.NodeDeployments.GetFlags(context.ValidationContext.ChainedHeaderToValidate);
-
-            if (this.keyValueRepository != null)
-            {
-                // Update the cache of Flags when we retrieve it.
-                this.keyValueRepository.SaveValueJson("deploymentflags", context.Flags);
-            }
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
- The deployment flags are cached when calculated as new blocks come in.
- The deployment flags are read from cache at startup, as they cannot have changed since shutdown.
- This gives a very big improvement on node startup.
- #337