### PR TITLE
Migrate to Blockcore.RocksDB

### DIFF
--- a/src/Features/Persistence/Blockcore.Persistence.RocksDb/Blockcore.Persistence.RocksDb.csproj
+++ b/src/Features/Persistence/Blockcore.Persistence.RocksDb/Blockcore.Persistence.RocksDb.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>RocksDb persistence common classes</Description>
@@ -10,12 +10,11 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Blockcore.RocksDB" Version="6.20.3.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.11" />
-    <PackageReference Include="RocksDbNative" Version="6.2.2" />
-    <PackageReference Include="RocksDbSharp" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Node/Blockcore.Node/Properties/launchSettings.json
+++ b/src/Node/Blockcore.Node/Properties/launchSettings.json
@@ -24,6 +24,10 @@
       "commandName": "Project",
       "commandLineArgs": "-server -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser -datadir=nodedata"
     },
+    "BTC (MAIN/LOCAL/ROCKSDB)": {
+      "commandName": "Project",
+      "commandLineArgs": "-server -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser -dbtype=rocksdb -datadir=data"
+    },
     "BTC (TEST/LOCAL)": {
       "commandName": "Project",
       "commandLineArgs": "-server -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser -datadir=nodedata -testnet"
@@ -111,6 +115,10 @@
     "EXOS (MAIN/LOCAL)": {
       "commandName": "Project",
       "commandLineArgs": "--chain=EXOS -server -whitelist=192.168.1.180 -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser -datadir=nodedata"
+    },
+    "EXOS (MAIN/LOCAL/ROCKSDB)": {
+      "commandName": "Project",
+      "commandLineArgs": "--chain=EXOS -server -whitelist=192.168.1.180 -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser -dbtype=rocksdb -datadir=data"
     },
     "RUTA (MAIN)": {
       "commandName": "Project",


### PR DESCRIPTION
- Replaces the existing RocksDB library that has not been updated since 2019.
- Needs verification by others, please run and verify.