### PR TITLE
Update to latest RocksDB package

### DIFF
--- a/src/Features/Persistence/Blockcore.Persistence.RocksDb/Blockcore.Persistence.RocksDb.csproj
+++ b/src/Features/Persistence/Blockcore.Persistence.RocksDb/Blockcore.Persistence.RocksDb.csproj
@@ -10,7 +10,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Blockcore.RocksDB" Version="6.20.3.2" />
+    <PackageReference Include="Blockcore.RocksDB" Version="6.20.3.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.11" />


### PR DESCRIPTION
- Enables Mac support without manual dependency installation.
- Linux still require some dependencies to be installed to use RocksDB.