### PR TITLE
Updates to BIP deployments for RSC and SBC

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.27</Version>
+    <Version>1.1.28</Version>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>Blockcore</Authors>

--- a/src/Networks/Blockcore.Networks.RoyalSportsCity/Networks/Deployments/RoyalSportsCityBIP9Deployments.cs
+++ b/src/Networks/Blockcore.Networks.RoyalSportsCity/Networks/Deployments/RoyalSportsCityBIP9Deployments.cs
@@ -10,13 +10,12 @@ namespace Blockcore.Networks.RoyalSportsCity.Networks.Deployments
    public class RoyalSportsCityBIP9Deployments : BIP9DeploymentsArray
    {
       // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
-      public const int TestDummy = 0;
-      public const int CSV = 1;
-      public const int Segwit = 2;
-      public const int ColdStaking = 3;
+      public const int CSV = 0;
+      public const int Segwit = 1;
+      public const int ColdStaking = 2;
 
       // The number of deployments.
-      public const int NumberOfDeployments = 4;
+      public const int NumberOfDeployments = 3;
 
       /// <summary>
       /// Constructs the BIP9 deployments array.

--- a/src/Networks/Blockcore.Networks.RoyalSportsCity/Networks/RoyalSportsCityMain.cs
+++ b/src/Networks/Blockcore.Networks.RoyalSportsCity/Networks/RoyalSportsCityMain.cs
@@ -91,10 +91,9 @@ namespace Blockcore.Networks.RoyalSportsCity.Networks
 
          var bip9Deployments = new RoyalSportsCityBIP9Deployments()
          {
-            [RoyalSportsCityBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 2,
-             new DateTime(2018, 12, 1, 0, 0, 0, DateTimeKind.Utc),
-             new DateTime(2019, 12, 1, 0, 0, 0, DateTimeKind.Utc),
-             BIP9DeploymentsParameters.DefaultMainnetThreshold)
+             [RoyalSportsCityBIP9Deployments.CSV] = new BIP9DeploymentsParameters("CSV", 0, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive),
+             [RoyalSportsCityBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive),
+             [RoyalSportsCityBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 2, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive),
          };
 
          Consensus = new Blockcore.Consensus.Consensus(

--- a/src/Networks/Blockcore.Networks.SeniorBlockCoin/Networks/Deployments/SeniorBlockCoinBIP9Deployments.cs
+++ b/src/Networks/Blockcore.Networks.SeniorBlockCoin/Networks/Deployments/SeniorBlockCoinBIP9Deployments.cs
@@ -10,13 +10,12 @@ namespace Blockcore.Networks.SeniorBlockCoin.Networks.Deployments
    public class SeniorBlockCoinBIP9Deployments : BIP9DeploymentsArray
    {
       // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
-      public const int TestDummy = 0;
-      public const int CSV = 1;
-      public const int Segwit = 2;
-      public const int ColdStaking = 3;
+      public const int CSV = 0;
+      public const int Segwit = 1;
+      public const int ColdStaking = 2;
 
       // The number of deployments.
-      public const int NumberOfDeployments = 4;
+      public const int NumberOfDeployments = 3;
 
       /// <summary>
       /// Constructs the BIP9 deployments array.

--- a/src/Networks/Blockcore.Networks.SeniorBlockCoin/Networks/SeniorBlockCoinMain.cs
+++ b/src/Networks/Blockcore.Networks.SeniorBlockCoin/Networks/SeniorBlockCoinMain.cs
@@ -91,10 +91,9 @@ namespace Blockcore.Networks.SeniorBlockCoin.Networks
 
          var bip9Deployments = new SeniorBlockCoinBIP9Deployments()
          {
-            [SeniorBlockCoinBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 2,
-             new DateTime(2018, 12, 1, 0, 0, 0, DateTimeKind.Utc),
-             new DateTime(2019, 12, 1, 0, 0, 0, DateTimeKind.Utc),
-             BIP9DeploymentsParameters.DefaultMainnetThreshold)
+             [SeniorBlockCoinBIP9Deployments.CSV] = new BIP9DeploymentsParameters("CSV", 0, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive),
+             [SeniorBlockCoinBIP9Deployments.Segwit] = new BIP9DeploymentsParameters("Segwit", 1, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive),
+             [SeniorBlockCoinBIP9Deployments.ColdStaking] = new BIP9DeploymentsParameters("ColdStaking", 2, BIP9DeploymentsParameters.AlwaysActive, 999999999, BIP9DeploymentsParameters.AlwaysActive),
          };
 
          Consensus = new Blockcore.Consensus.Consensus(


### PR DESCRIPTION
- This makes the BIP deployments active from genesis.
- This fixes issue where nodes disconnected from other nodes that does not signal Segwit support.