### PR TITLE
Add endpoint to return the network weight for POS chains

### DIFF
--- a/src/Blockcore/Interfaces/INetworkWeight.cs
+++ b/src/Blockcore/Interfaces/INetworkWeight.cs
@@ -1,0 +1,9 @@
+﻿using NBitcoin;
+
+namespace Blockcore.Interfaces
+{
+    public interface INetworkWeight
+    {
+        double GetPosNetworkWeight();
+    }
+}

--- a/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
+++ b/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
@@ -95,7 +95,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
                 double networkWeight = this.posMinting.GetNetworkWeight();
                 double posDifficulty = this.posMinting.GetDifficulty(null);
 
-                return this.Json(new GetNetworkStakingInfoModel { Difficulty =posDifficulty, NetStakeWeight = (long)networkWeight });
+                return this.Json(new GetNetworkStakingInfoModel { Difficulty = posDifficulty, NetStakeWeight = (long)networkWeight });
             }
             catch (Exception e)
             {

--- a/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
+++ b/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
@@ -66,7 +66,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
             try
             {
                 if (!this.fullNode.Network.Consensus.IsProofOfStake)
-                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method not available for Proof of Stake");
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method only available for Proof of Stake");
 
                 GetStakingInfoModel model = this.posMinting != null ? this.posMinting.GetGetStakingInfoModel() : new GetStakingInfoModel();
 
@@ -90,7 +90,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
             try
             {
                 if (!this.fullNode.Network.Consensus.IsProofOfStake)
-                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method not available for Proof of Stake");
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method only available for Proof of Stake");
 
                 double networkWeight = this.posMinting.GetNetworkWeight();
                 double posDifficulty = this.posMinting.GetDifficulty(null);
@@ -118,7 +118,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
             try
             {
                 if (!this.fullNode.Network.Consensus.IsProofOfStake)
-                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method not available for Proof of Stake");
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method only available for Proof of Stake");
 
                 if (!this.ModelState.IsValid)
                 {
@@ -164,7 +164,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
             try
             {
                 if (!this.fullNode.Network.Consensus.IsProofOfStake)
-                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method not available for Proof of Stake");
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method only available for Proof of Stake");
 
                 this.fullNode.NodeFeature<MiningFeature>(true).StopStaking();
                 return this.Ok();
@@ -187,7 +187,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
             try
             {
                 if (!this.fullNode.Network.Consensus.IsProofOfStake)
-                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method not available for Proof of Stake");
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method only available for Proof of Stake");
 
                 if (!this.minerSettings.EnforceStakingFlag)
                     return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Forbidden, "Operation not allowed", "This operation is only allowed if EnforceStakingFlag is true");
@@ -221,7 +221,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
             try
             {
                 if (!this.fullNode.Network.Consensus.IsProofOfStake)
-                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method not available for Proof of Stake");
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method only available for Proof of Stake");
 
                 if (!this.minerSettings.EnforceStakingFlag)
                     return ErrorHelpers.BuildErrorResponse(HttpStatusCode.Forbidden, "Operation not allowed", "This operation is only allowed if EnforceStakingFlag is true");

--- a/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
+++ b/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
@@ -80,6 +80,31 @@ namespace Blockcore.Features.Miner.Api.Controllers
         }
 
         /// <summary>
+        /// Get staking info from the miner.
+        /// </summary>
+        /// <returns>All staking info details as per the GetStakingInfoModel.</returns>
+        [Route("getnetworkstakinginfo")]
+        [HttpGet]
+        public IActionResult GetNetworkStakingInfo()
+        {
+            try
+            {
+                if (!this.fullNode.Network.Consensus.IsProofOfStake)
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.MethodNotAllowed, "Method not allowed", "Method not available for Proof of Stake");
+
+                double networkWeight = this.posMinting.GetNetworkWeight();
+                double posDifficulty = this.posMinting.GetDifficulty(null);
+
+                return this.Json(new GetNetworkStakingInfoModel { Difficulty =posDifficulty, NetStakeWeight = (long)networkWeight });
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
         /// Start staking.
         /// </summary>
         /// <param name="request">The name and password of the wallet to stake.</param>

--- a/src/Features/Blockcore.Features.Miner/Api/Models/GetNetworkStakingInfoModel.cs
+++ b/src/Features/Blockcore.Features.Miner/Api/Models/GetNetworkStakingInfoModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Blockcore.Features.Miner.Api.Models
+{
+    /// <summary>
+    /// Data structure returned by RPC command "getstakinginfo".
+    /// </summary>
+    public class GetNetworkStakingInfoModel
+    {
+        /// <summary>Target difficulty that the next block must meet.</summary>
+        [JsonProperty(PropertyName = "difficulty")]
+        public double Difficulty { get; set; }
+
+        /// <summary>Estimation of the total staking weight of all nodes on the network.</summary>
+        [JsonProperty(PropertyName = "netStakeWeight")]
+        public long NetStakeWeight { get; set; }
+      
+    }
+}

--- a/src/Features/Blockcore.Features.Miner/Blockcore.Features.Miner.csproj
+++ b/src/Features/Blockcore.Features.Miner/Blockcore.Features.Miner.csproj
@@ -18,9 +18,6 @@
     <ProjectReference Include="..\Blockcore.Features.Wallet\Blockcore.Features.Wallet.csproj" />
     <ProjectReference Include="..\..\Blockcore\Blockcore.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Api\" />
-  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1701;1702;1705;IDE0008;</NoWarn>
     <DocumentationFile>

--- a/src/Features/Blockcore.Features.Miner/MiningFeature.cs
+++ b/src/Features/Blockcore.Features.Miner/MiningFeature.cs
@@ -17,6 +17,7 @@ using Blockcore.Features.Miner.Staking;
 using Blockcore.Features.RPC;
 using Blockcore.Features.Wallet;
 using Blockcore.Features.Wallet.UI;
+using Blockcore.Interfaces;
 using Blockcore.Interfaces.UI;
 using Blockcore.Mining;
 using Blockcore.Networks;
@@ -256,7 +257,8 @@ namespace Blockcore.Features.Miner
                     .FeatureServices(services =>
                     {
                         services.AddSingleton<IPowMining, PowMining>();
-                        services.AddSingleton<IPosMinting, PosMinting>();
+                        services.AddSingleton<IPosMinting, PosMinting>()
+                            .AddSingleton<INetworkWeight, PosMinting>(provider => (PosMinting)provider.GetService<IPosMinting>());
                         services.AddSingleton<IBlockProvider, BlockProvider>();
                         services.AddSingleton<BlockDefinition, PowBlockDefinition>();
                         services.AddSingleton<BlockDefinition, PosBlockDefinition>();

--- a/src/Features/Blockcore.Features.Miner/Staking/PosMinting.cs
+++ b/src/Features/Blockcore.Features.Miner/Staking/PosMinting.cs
@@ -71,7 +71,7 @@ namespace Blockcore.Features.Miner.Staking
     /// and the new value depends on the kernel, it is hard to predict its value in the future.
     /// </para>
     /// </remarks>
-    public class PosMinting : IPosMinting
+    public class PosMinting : IPosMinting, INetworkWeight
     {
         /// <summary>
         /// Indicates the current state: idle, staking requested, staking in progress and stop staking requested.
@@ -1187,6 +1187,11 @@ namespace Blockcore.Features.Miner.Staking
             res *= this.network.Consensus.ProofOfStakeTimestampMask + 1;
 
             return res;
+        }
+
+        public double GetPosNetworkWeight()
+        {
+            return GetNetworkWeight();
         }
 
         /// <inheritdoc/>

--- a/src/Features/Blockcore.Features.RPC/Controllers/FullNodeController.cs
+++ b/src/Features/Blockcore.Features.RPC/Controllers/FullNodeController.cs
@@ -50,6 +50,9 @@ namespace Blockcore.Features.RPC.Controllers
         /// <summary>An interface implementation used to retrieve the network difficulty target.</summary>
         private readonly INetworkDifficulty networkDifficulty;
 
+        /// <summary>An interface implementation used to retrieve the total network weight.</summary>
+        private readonly INetworkWeight networkWeight;
+
         /// <summary>An interface implementation for the blockstore.</summary>
         private readonly IBlockStore blockStore;
 
@@ -73,7 +76,8 @@ namespace Blockcore.Features.RPC.Controllers
             IConsensusManager consensusManager = null,
             IBlockStore blockStore = null,
             IInitialBlockDownloadState ibdState = null,
-            IStakeChain stakeChain = null)
+            IStakeChain stakeChain = null,
+            INetworkWeight networkWeight = null)
             : base(
                   fullNode: fullNode,
                   network: network,
@@ -91,6 +95,7 @@ namespace Blockcore.Features.RPC.Controllers
             this.blockStore = blockStore;
             this.ibdState = ibdState;
             this.stakeChain = stakeChain;
+            this.networkWeight = networkWeight;
         }
 
         /// <summary>
@@ -462,6 +467,7 @@ namespace Blockcore.Features.RPC.Controllers
                 Headers = (uint)(this.ChainIndexer?.Height ?? 0),
                 BestBlockHash = this.ChainState?.ConsensusTip?.HashBlock,
                 Difficulty = this.GetNetworkDifficulty()?.Difficulty ?? 0.0,
+                NetworkWeight = (long)this.GetPosNetworkWeight(),
                 MedianTime = this.ChainState?.ConsensusTip?.GetMedianTimePast().ToUnixTimeSeconds() ?? 0,
                 VerificationProgress = 0.0,
                 IsInitialBlockDownload = this.ibdState?.IsInitialBlockDownload() ?? true,
@@ -549,6 +555,11 @@ namespace Blockcore.Features.RPC.Controllers
         private Target GetNetworkDifficulty()
         {
             return this.networkDifficulty?.GetNetworkDifficulty();
+        }
+
+        private double GetPosNetworkWeight()
+        {
+            return this.networkWeight?.GetPosNetworkWeight() ?? 0;
         }
     }
 }

--- a/src/Features/Blockcore.Features.RPC/Models/BlockchainInfoModel.cs
+++ b/src/Features/Blockcore.Features.RPC/Models/BlockchainInfoModel.cs
@@ -11,6 +11,7 @@ namespace Blockcore.Features.RPC.Models
     // * "headers": xxxxxx,            (numeric) the current number of headers we have validated
     //  "bestblockhash": "...",       (string) the hash of the currently best block
     //  "difficulty": xxxxxx,         (numeric) the current difficulty
+    //  "networkWeight: xxxxx,         (numeric) the total network weight
     // * "mediantime": xxxxxx,         (numeric) median time for the current best block
     // * "verificationprogress": xxxx, (numeric) estimate of verification progress[0..1]
     // * "initialblockdownload": xxxx, (bool) (debug information) estimate of whether this node is in Initial Block Download mode.
@@ -64,6 +65,9 @@ namespace Blockcore.Features.RPC.Models
 
         [JsonProperty(PropertyName = "difficulty")]
         public double Difficulty { get; set; }
+        
+        [JsonProperty(PropertyName = "networkWeight")]
+        public long NetworkWeight { get; set; }
 
         [JsonProperty(PropertyName = "mediantime")]
         public long MedianTime { get; set; }

--- a/src/Node/Blockcore.Node/Properties/launchSettings.json
+++ b/src/Node/Blockcore.Node/Properties/launchSettings.json
@@ -76,6 +76,10 @@
       "commandName": "Project",
       "commandLineArgs": "--chain=X42 -server -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser -datadir=nodedata -testnet"
     },
+    "XDS (MAIN)": {
+      "commandName": "Project",
+      "commandLineArgs": "--chain=XDS -server -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser"
+    },
     "XDS (MAIN/LOCAL)": {
       "commandName": "Project",
       "commandLineArgs": "--chain=XDS -server -rpcallowip=127.0.0.1 -rpcbind=127.0.0.1 -rpcpassword=rpcpassword -rpcuser=rpcuser  -datadir=nodedata"

--- a/src/Tests/Blockcore.Features.Miner.Tests/Controllers/StakingControllerTest.cs
+++ b/src/Tests/Blockcore.Features.Miner.Tests/Controllers/StakingControllerTest.cs
@@ -262,7 +262,7 @@ namespace Blockcore.Features.Miner.Tests.Controllers
 
                 ErrorModel error = errorResponse.Errors[0];
                 Assert.Equal(405, error.Status);
-                Assert.Equal("Method not available for Proof of Stake", error.Description);
+                Assert.Equal("Method only available for Proof of Stake", error.Description);
             }
         }
     }


### PR DESCRIPTION
Endpoints to get the POS network difficulty to be used with the indexer for this issue
https://github.com/block-core/blockcore-indexer/issues/56

There are two approaches this can go:

- the approach of this PR where we have an additional endpoint for the POS difficulty and the current network weight.
- adding the network weight and difficulty to each block on the api method `GetBlock` (then on the explorer we can display the network weight on each block)

(note the difficulty on POS is calculated slightly differently when it comes to calculating the network weight)

