### PR TITLE
Display background tasks diagnostics only with debug=tasks param

### DIFF
--- a/src/Blockcore/Base/BaseFeature.cs
+++ b/src/Blockcore/Base/BaseFeature.cs
@@ -247,7 +247,7 @@ namespace Blockcore.Base
 
             this.chainState.ConsensusTip = this.consensusManager.Tip;
 
-            this.nodeStats.RegisterStats(sb => sb.Append(this.asyncProvider.GetStatistics(!this.nodeSettings.Log.DebugArgs.Any())), StatsType.Component, this.GetType().Name, 100);
+            this.nodeStats.RegisterStats(sb => sb.Append(this.asyncProvider.GetStatistics(!this.nodeSettings.Log.DebugArgs.Any(a => a == "tasks"))), StatsType.Component, this.GetType().Name, 100);
 
             ((IBlockStoreQueue)this.blockStore).ReindexChain(this.consensusManager, this.nodeLifetime.ApplicationStopping);
         }

--- a/src/Blockcore/Configuration/NodeSettings.cs
+++ b/src/Blockcore/Configuration/NodeSettings.cs
@@ -383,7 +383,7 @@ namespace Blockcore.Configuration
             builder.AppendLine($"-conf=<Path>              Path to the configuration file. Defaults to {defaults.ConfigurationFile}.");
             builder.AppendLine($"-datadir=<Path>           Path to the data directory. Defaults to {defaults.DataDir}.");
             builder.AppendLine($"-datadirroot=<Path>       The path to the root data directory, which holds all node data on the machine. Defaults to 'Blockcore'.");
-            builder.AppendLine($"-debug[=<string>]         Set 'Debug' logging level. Specify what to log via e.g. '-debug=Blockcore.Miner,Blockcore.Wallet'.");
+            builder.AppendLine($"-debug[=<string>]         Set 'Debug' logging level (add -debug=tasks for backround tasks). Specify what to log via e.g. '-debug=Blockcore.Miner,Blockcore.Wallet'.");
             builder.AppendLine($"-loglevel=<string>        Direct control over the logging level: '-loglevel=trace/debug/info/warn/error/fatal'.");
 
             // Can be overridden in configuration file.


### PR DESCRIPTION
Right now when we set a debug param we always display the bellow output, this PR requires users to specifically set debug=tasks to show it

![image](https://user-images.githubusercontent.com/7487930/152195733-168b4b9e-39bb-42f7-aaaf-190ee0bcc208.png)
