### PR TITLE
XRC HardFork - X11, DigiShield POW algo

### DIFF
--- a/src/Networks/Blockcore.Networks.XRC/Blockcore.Networks.XRC.csproj
+++ b/src/Networks/Blockcore.Networks.XRC/Blockcore.Networks.XRC.csproj
@@ -31,8 +31,4 @@
   <ItemGroup>
     <Folder Include="Rules\" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-  </ItemGroup>
 </Project>

--- a/src/Networks/Blockcore.Networks.XRC/Consensus/XRCBlockHeader.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Consensus/XRCBlockHeader.cs
@@ -10,7 +10,13 @@ namespace Blockcore.Networks.XRC.Consensus
     {
         private const int X13_HASH_MINERUNCOMPATIBLE = 1;
         private const int X13_HASH_MINERCOMPATIBLE = 2;
-        private const uint XRC_X13_HASH_HARDFORK = 1541879606;
+
+        public XRCConsensusProtocol Consensus { get; set; }
+
+        public XRCBlockHeader(XRCConsensusProtocol consensus)
+        {
+            this.Consensus = consensus;
+        }
 
         public override uint256 GetHash()
         {
@@ -43,8 +49,13 @@ namespace Blockcore.Networks.XRC.Consensus
             using (var ms = new MemoryStream())
             {
                 this.ReadWriteHashingStream(new BitcoinStream(ms, true));
+                
+                if (this.Time > this.Consensus.PowDigiShieldX11Time)
+                {
+                    return XRCHashX11.Instance.Hash(this.ToBytes());
+                }
                 //block HardFork - height: 1648, time - 1541879606, hash - a75312cab7cf2a6ee89ab33bcb0ab9f96676fbc965041d50b889d9469eff6cdb 
-                if (this.Time > XRC_X13_HASH_HARDFORK)
+                else if (this.Time > this.Consensus.PowLimit2Time)
                 {
                     return XRCHashX13.Instance.Hash(this.ToBytes(), X13_HASH_MINERCOMPATIBLE);
                 }

--- a/src/Networks/Blockcore.Networks.XRC/Consensus/XRCCoinType.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Consensus/XRCCoinType.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blockcore.Networks.XRC.Consensus
+{
+    public class XRCCoinType
+    {
+        public enum CoinTypes
+        {
+            /// <summary>
+            /// XRhodium Main Network
+            /// </summary>
+            XRCMain = 10291,
+
+            /// <summary>
+            /// Testnet
+            /// </summary>
+            XRCTest = 1,
+
+            /// <summary>
+            /// RegTest
+            /// </summary>
+            XRCReg = 1
+        }
+    }
+}

--- a/src/Networks/Blockcore.Networks.XRC/Consensus/XRCConsensus.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Consensus/XRCConsensus.cs
@@ -48,8 +48,6 @@ namespace Blockcore.Networks.XRC.Consensus
 
         public Target PowLimit { get; }
         public Target PowLimit2 { get; }
-        public int PowLimit2Height { get; }
-        public uint PowLimit2Time { get; }
 
         public TimeSpan TargetTimespan { get; }
 
@@ -131,8 +129,6 @@ namespace Blockcore.Networks.XRC.Consensus
             bool powNoRetargeting,
             Target powLimit,
             Target powLimit2,
-            int powLimit2Height,
-            uint powLimit2Time,
             uint256 minimumChainWork,
             bool isProofOfStake,
             int lastPowBlock,
@@ -158,8 +154,6 @@ namespace Blockcore.Networks.XRC.Consensus
             this.BIP34Hash = bip34Hash;
             this.PowLimit = powLimit;
             this.PowLimit2 = powLimit2;
-            this.PowLimit2Height = powLimit2Height;
-            this.PowLimit2Time = powLimit2Time;
             this.TargetTimespan = targetTimespan;
             this.TargetSpacing = targetSpacing;
             this.PowAllowMinDifficultyBlocks = powAllowMinDifficultyBlocks;

--- a/src/Networks/Blockcore.Networks.XRC/Consensus/XRCConsensusFactory.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Consensus/XRCConsensusFactory.cs
@@ -14,7 +14,7 @@ namespace Blockcore.Networks.XRC.Consensus
 
         public override BlockHeader CreateBlockHeader()
         {
-            return new XRCBlockHeader();
+            return new XRCBlockHeader((XRCConsensusProtocol)this.Protocol);
         }
     }
 }

--- a/src/Networks/Blockcore.Networks.XRC/Consensus/XRCConsensusProtocol.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Consensus/XRCConsensusProtocol.cs
@@ -1,0 +1,12 @@
+﻿using Blockcore.Consensus;
+
+namespace Blockcore.Networks.XRC.Consensus
+{
+    public class XRCConsensusProtocol : ConsensusProtocol
+    {
+        public int PowLimit2Height { get; set; }
+        public uint PowLimit2Time { get; set; }
+        public int PowDigiShieldX11Height { get; set; }
+        public uint PowDigiShieldX11Time { get; set; }
+    }
+}

--- a/src/Networks/Blockcore.Networks.XRC/Consensus/XRCNetwork.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Consensus/XRCNetwork.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using Blockcore.Consensus;
+using Blockcore.Features.Consensus.Rules.CommonRules;
+using Blockcore.Features.Consensus.Rules.UtxosetRules;
+using Blockcore.Features.MemoryPool.Rules;
+using Blockcore.Networks.XRC.Rules;
+using Blockcore.Consensus.BlockInfo;
+using Blockcore.Consensus.ScriptInfo;
+using Blockcore.Consensus.TransactionInfo;
+using NBitcoin;
+using NBitcoin.DataEncoders;
+
+namespace Blockcore.Networks.XRC.Consensus
+{
+    public class XRCNetwork : Network
+    {
+        public Block CreateXRCGenesisBlock(XRCConsensusFactory consensusFactory, uint nTime, uint nNonce, uint nBits, int nVersion, string pubKey)
+        {
+            string message = "Release the Kraken!!! Zeus";
+            return CreateXRCGenesisBlock(consensusFactory, message, nTime, nNonce, nBits, nVersion, pubKey);
+        }
+
+        private Block CreateXRCGenesisBlock(XRCConsensusFactory consensusFactory, string message, uint nTime, uint nNonce, uint nBits, int nVersion, string pubKey)
+        {
+            //nTime = 1512043200 => Thursday, November 30, 2017 12:00:00 PM (born XRC)
+            //nTime = 1527811200 => Friday, Jun 1, 2017 12:00:00 PM (born TestXRC)
+            //nBits = 0x1d00ffff (it is exactly 0x1b = 27 bytes long) => 0x00ffff0000000000000000000000000000000000000000000000000000 => 1
+            //nNonce = XTimes to trying to find a genesis block
+            Transaction txNew = consensusFactory.CreateTransaction();
+            txNew.Version = 2;
+            if (txNew is IPosTransactionWithTime posTx)
+                posTx.Time = nTime;
+            txNew.AddInput(new TxIn()
+            {
+                ScriptSig = new Script(Op.GetPushOp(nBits), new Op()
+                {
+                    Code = (OpcodeType)0x1,
+                    PushData = new[] { (byte)4 }
+                }, Op.GetPushOp(Encoders.ASCII.DecodeData(message)))
+            });
+            txNew.AddOutput(new TxOut()
+            {
+                Value = Money.Zero,
+                ScriptPubKey = Script.FromBytesUnsafe(Encoders.Hex.DecodeData(pubKey))
+            });
+
+            Block genesis = consensusFactory.CreateBlock();
+            genesis.Header.BlockTime = Utils.UnixTimeToDateTime(nTime);
+            genesis.Header.Bits = nBits;
+            genesis.Header.Nonce = nNonce;
+            genesis.Header.Version = nVersion;
+            genesis.Transactions.Add(txNew);
+            genesis.Header.HashPrevBlock = uint256.Zero;
+            genesis.UpdateMerkleRoot();
+            return genesis;
+        }
+
+        protected void RegisterRules(IConsensus consensus)
+        {
+            consensus.ConsensusRules
+                .Register<HeaderTimeChecksRule>()
+                .Register<XRCCheckDifficultyPowRule>()
+                .Register<XRCHeaderVersionRule>();
+
+            consensus.ConsensusRules
+                .Register<BlockMerkleRootRule>();
+
+            consensus.ConsensusRules
+                .Register<SetActivationDeploymentsPartialValidationRule>()
+
+                .Register<TransactionLocktimeActivationRule>()
+                .Register<CoinbaseHeightActivationRule>()
+                .Register<WitnessCommitmentsRule>()
+                .Register<BlockSizeRule>()
+
+                .Register<EnsureCoinbaseRule>()
+                .Register<CheckPowTransactionRule>()
+                .Register<CheckSigOpsRule>();
+
+            consensus.ConsensusRules
+                .Register<SetActivationDeploymentsFullValidationRule>()
+
+                // rules that require the store to be loaded (coinview)
+                .Register<FetchUtxosetRule>()
+                .Register<TransactionDuplicationActivationRule>()
+                .Register<CheckPowUtxosetPowRule>()
+                .Register<PushUtxosetRule>()
+                .Register<FlushUtxosetRule>();
+        }
+
+        protected void RegisterMempoolRules(IConsensus consensus)
+        {
+            consensus.MempoolRules = new List<Type>()
+            {
+                typeof(CheckConflictsMempoolRule),
+                typeof(CheckCoinViewMempoolRule),
+                typeof(CreateMempoolEntryMempoolRule),
+                typeof(CheckSigOpsMempoolRule),
+                typeof(CheckFeeMempoolRule),
+                typeof(CheckRateLimitMempoolRule),
+                typeof(CheckAncestorsMempoolRule),
+                typeof(CheckReplacementMempoolRule),
+                typeof(CheckAllInputsMempoolRule),
+                typeof(CheckTxOutDustRule)
+            };
+        }
+    }
+}

--- a/src/Networks/Blockcore.Networks.XRC/Crypto/XRCHashX11.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Crypto/XRCHashX11.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using HashLib;
+using NBitcoin;
+
+namespace Blockcore.Networks.XRC.Crypto
+{
+    internal class XRCHashX11
+    {
+        private readonly List<IHash> hashers;
+
+        private readonly object hashLock;
+
+        private static readonly Lazy<XRCHashX11> SingletonInstance = new Lazy<XRCHashX11>(LazyThreadSafetyMode.PublicationOnly);
+
+        public XRCHashX11()
+        {
+            this.hashers = new List<IHash>
+            {
+                HashFactory.Crypto.SHA3.CreateBlake512(),
+                HashFactory.Crypto.SHA3.CreateBlueMidnightWish512(),
+                HashFactory.Crypto.SHA3.CreateGroestl512(),
+                HashFactory.Crypto.SHA3.CreateSkein512_Custom(),
+                HashFactory.Crypto.SHA3.CreateJH512(),
+                HashFactory.Crypto.SHA3.CreateKeccak512(),
+                HashFactory.Crypto.SHA3.CreateLuffa512(),
+                HashFactory.Crypto.SHA3.CreateCubeHash512(),
+                HashFactory.Crypto.SHA3.CreateSHAvite3_512_Custom(),
+                HashFactory.Crypto.SHA3.CreateSIMD512(),
+                HashFactory.Crypto.SHA3.CreateEcho512(),
+            };
+
+            this.hashLock = new object();
+            this.Multiplier = 1;
+        }
+
+        public uint Multiplier { get; private set; }
+
+        /// <summary>
+        /// using the instance method is not thread safe.
+        /// to calling the hashing method in a multi threaded environment use the create() method
+        /// </summary>
+        public static XRCHashX11 Instance => SingletonInstance.Value;
+
+        public static XRCHashX11 Create()
+        {
+            return new XRCHashX11();
+        }
+
+        public uint256 Hash(byte[] input)
+        {
+            var buffer = input;
+
+            lock (this.hashLock)
+            {
+                List<IHash> hashers = this.hashers;
+
+                foreach (IHash hasher in hashers)
+                {
+                    buffer = hasher.ComputeBytes(buffer).GetBytes();
+                }
+            }
+
+            return new uint256(buffer.Take(32).ToArray());
+        }
+    }
+}

--- a/src/Networks/Blockcore.Networks.XRC/Rules/XRCCheckDifficultyPowRule.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Rules/XRCCheckDifficultyPowRule.cs
@@ -146,7 +146,9 @@ namespace Blockcore.Networks.XRC.Rules
             ChainedHeader firstBlock = chainedHeaderToValidate.GetAncestor(height - nAveragingInterval);
 
             var XRCConsensusProtocol = (XRCConsensusProtocol)consensus.ConsensusFactory.Protocol;
-            if ((height - XRCConsensusProtocol.PowDigiShieldX11Height) <= (nAveragingInterval + this.MedianTimeSpan))
+
+            if (((height - XRCConsensusProtocol.PowDigiShieldX11Height) <= (nAveragingInterval + this.MedianTimeSpan))
+                && (consensus.CoinType == (int)XRCCoinType.CoinTypes.XRCMain))
             {
                 return new Target(new uint256("000000000001a61a000000000000000000000000000000000000000000000000"));
             }

--- a/src/Networks/Blockcore.Networks.XRC/Rules/XRCCheckDifficultyPowRule.cs
+++ b/src/Networks/Blockcore.Networks.XRC/Rules/XRCCheckDifficultyPowRule.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Blockcore.Consensus;
 using Blockcore.Consensus.Chain;
 using Blockcore.Consensus.Rules;
@@ -12,7 +14,7 @@ namespace Blockcore.Networks.XRC.Rules
     public class XRCCheckDifficultyPowRule : HeaderValidationConsensusRule
     {
         private static BigInteger pow256 = BigInteger.ValueOf(2).Pow(256);
-
+        int MedianTimeSpan = 11;
         public override void Run(RuleContext context)
         {
             if (!CheckProofOfWork((XRCBlockHeader)context.ValidationContext.ChainedHeaderToValidate.Header))
@@ -47,14 +49,20 @@ namespace Blockcore.Networks.XRC.Rules
             if (chainedHeaderToValidate.Height == 0)
                 return consensus.PowLimit2;
 
+            var XRCConsensusProtocol = (XRCConsensusProtocol)consensus.ConsensusFactory.Protocol;
+
             //hard fork
-            if (chainedHeaderToValidate.Height == consensus.PowLimit2Height + 1)
+            if (chainedHeaderToValidate.Height == XRCConsensusProtocol.PowLimit2Height + 1)
                 return consensus.PowLimit;
+
+            //hard fork 2 - DigiShield + X11
+            if (chainedHeaderToValidate.Height > XRCConsensusProtocol.PowDigiShieldX11Height)
+                return GetWorkRequiredDigiShield(chainedHeaderToValidate, consensus);
 
             Target proofOfWorkLimit;
 
             // Hard fork to higher difficulty
-            if (chainedHeaderToValidate.Height > consensus.PowLimit2Height)
+            if (chainedHeaderToValidate.Height > XRCConsensusProtocol.PowLimit2Height)
             {
                 proofOfWorkLimit = consensus.PowLimit;
             }
@@ -120,6 +128,70 @@ namespace Blockcore.Networks.XRC.Rules
                 finalTarget = proofOfWorkLimit;
 
             return finalTarget;
+        }
+
+        public Target GetWorkRequiredDigiShield(ChainedHeader chainedHeaderToValidate, XRCConsensus consensus)
+        {
+            var nAveragingInterval = 10 * 5; // block
+            var multiAlgoTargetSpacingV4 = 10 * 60; // seconds
+            var nAveragingTargetTimespanV4 = nAveragingInterval * multiAlgoTargetSpacingV4;
+            var nMaxAdjustDownV4 = 16;
+            var nMaxAdjustUpV4 = 8;
+            var nMinActualTimespanV4 = TimeSpan.FromSeconds(nAveragingTargetTimespanV4 * (100 - nMaxAdjustUpV4) / 100);
+            var nMaxActualTimespanV4 = TimeSpan.FromSeconds(nAveragingTargetTimespanV4 * (100 + nMaxAdjustDownV4) / 100);
+
+            var height = chainedHeaderToValidate.Height;
+            Target proofOfWorkLimit = consensus.PowLimit;
+            ChainedHeader lastBlock = chainedHeaderToValidate.Previous;
+            ChainedHeader firstBlock = chainedHeaderToValidate.GetAncestor(height - nAveragingInterval);
+
+            var XRCConsensusProtocol = (XRCConsensusProtocol)consensus.ConsensusFactory.Protocol;
+            if ((height - XRCConsensusProtocol.PowDigiShieldX11Height) <= (nAveragingInterval + this.MedianTimeSpan))
+            {
+                return new Target(new uint256("000000000001a61a000000000000000000000000000000000000000000000000"));
+            }
+
+            // Limit adjustment step
+            // Use medians to prevent time-warp attacks
+            TimeSpan nActualTimespan = GetAverageTimePast(lastBlock) - GetAverageTimePast(firstBlock);
+            nActualTimespan = TimeSpan.FromSeconds(nAveragingTargetTimespanV4
+                                    + (nActualTimespan.TotalSeconds - nAveragingTargetTimespanV4) / 4);
+
+            if (nActualTimespan < nMinActualTimespanV4)
+                nActualTimespan = nMinActualTimespanV4;
+            if (nActualTimespan > nMaxActualTimespanV4)
+                nActualTimespan = nMaxActualTimespanV4;
+
+            // Retarget.
+            BigInteger newTarget = lastBlock.Header.Bits.ToBigInteger();
+
+            newTarget = newTarget.Multiply(BigInteger.ValueOf((long)nActualTimespan.TotalSeconds));
+            newTarget = newTarget.Divide(BigInteger.ValueOf((long)nAveragingTargetTimespanV4));
+
+            var finalTarget = new Target(newTarget);
+            if (finalTarget > proofOfWorkLimit)
+                finalTarget = proofOfWorkLimit;
+
+            return finalTarget;
+        }
+
+        public DateTimeOffset GetAverageTimePast(ChainedHeader chainedHeaderToValidate)
+        {
+            var median = new List<DateTimeOffset>();
+
+            ChainedHeader chainedHeader = chainedHeaderToValidate;
+            for (int i = 0; i < this.MedianTimeSpan && chainedHeader != null; i++, chainedHeader = chainedHeader.Previous)
+                median.Add(chainedHeader.Header.BlockTime);
+
+            median.Sort();
+
+            DateTimeOffset firstTimespan = median.First();
+            DateTimeOffset lastTimespan = median.Last();
+            TimeSpan differenceTimespan = lastTimespan - firstTimespan;
+            var timespan = differenceTimespan.TotalSeconds / 2;
+            DateTimeOffset averageDateTime = firstTimespan.AddSeconds((long)timespan);
+
+            return averageDateTime;
         }
 
         private long GetDifficultyAdjustmentInterval(IConsensus consensus)

--- a/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
@@ -140,12 +140,18 @@ namespace Blockcore.Networks.XRC
             this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 23 };
 
             this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+            this.Checkpoints.Add(17, new CheckpointInfo(new uint256("2430c4151e10cdc5ccbdea56b909c7c37ab2a852d3e7fb908e0a32493e2ac706")));
+            this.Checkpoints.Add(117, new CheckpointInfo(new uint256("bf3082be3b2da88187ebeb902548b41dbff3bcac6687352e0c47d902acd28e62")));
+            this.Checkpoints.Add(400, new CheckpointInfo(new uint256("20cb04127f12c1ae7a04ee6dc4c7e36f4c85ee2038c92126b3fd537110d96595")));
+            this.Checkpoints.Add(800, new CheckpointInfo(new uint256("df37ca401ecccfc6dedf68ab76a7161496ad93d47c2a474075efb3220e3f3526")));
             this.Checkpoints.Add(2015, new CheckpointInfo(new uint256("574605587514315bf8dac135c093a50e5982cb26e47ac78f2a712b9289f5cc7e")));
             this.Checkpoints.Add(10079, new CheckpointInfo(new uint256("a960cf32c570de76b4a2035831608bf884c3b8dad7a6e77d6a40b5dcb7f84f5e")));
             this.Checkpoints.Add(18143, new CheckpointInfo(new uint256("fb2df6739907716b4a9c20d45f7db968481b76d97a4bd279a14d19d4dad2a18a")));
             this.Checkpoints.Add(26207, new CheckpointInfo(new uint256("90034dfe536ef2c692d9fad3fc95ea16d0b3a004cb23677eb0cc6ba51b38fc40")));
+            this.Checkpoints.Add(26800, new CheckpointInfo(new uint256("c4efd4b6fa294fd72ab6f614dd6705eea43d0a83cd03d597c3214eaaf857a4b6")));
             this.Checkpoints.Add(34271, new CheckpointInfo(new uint256("f8e3cf72102112a26a7af75fff195321226023a2e2617723b5c6259d63d419da")));
             this.Checkpoints.Add(42335, new CheckpointInfo(new uint256("8bbeb434aba05f41ed2f4d4091289d7c6cd4f6e6168dfc207361b3b53d885970")));
+            this.Checkpoints.Add(43034, new CheckpointInfo(new uint256("4df06bd483d2c4ccde5cd1efe3b2ea7d969c41e5923a74c2bba1656a41fc6891")));
             this.Checkpoints.Add(50399, new CheckpointInfo(new uint256("07e3d655eb39be8e1297ff1835aa09ebe68ca2a1c31d9b412ac029f9066e75e1")));
             this.Checkpoints.Add(58463, new CheckpointInfo(new uint256("88b714a59faa29037b1cf63eb35bcd243a60768bb2cc21cfb500c77fe67d3369")));
             this.Checkpoints.Add(66527, new CheckpointInfo(new uint256("113d337fe7b6aa8d059a674bc339506fa9f69e0c390e978582253c6dd9dcd5b6")));
@@ -154,11 +160,11 @@ namespace Blockcore.Networks.XRC
             this.Checkpoints.Add(90719, new CheckpointInfo(new uint256("782ac4559002e425cc63fe71bb1cb89e03305cc1270d2846baa451d4d4bf9c43")));
             this.Checkpoints.Add(98783, new CheckpointInfo(new uint256("53505abcda5dff8278113d67949b260ce6a79a01dd6b775e6cfc50619d7d0656")));
             this.Checkpoints.Add(106847, new CheckpointInfo(new uint256("6661f25d3850a2cb95a2dd3c1eb7752a7ab9f780c745a8b8fd5ce9fba5acfdbf")));
+            this.Checkpoints.Add(110000, new CheckpointInfo(new uint256("d1d1282681f20223a281393528e6c624539e60177ecb42ab4512555974ac7775")));
             this.Checkpoints.Add(114911, new CheckpointInfo(new uint256("f343f45fdff7bede9db8bb10ab1c00ebcd7c173823ef6e49e493ed86e71d2f27")));
             this.Checkpoints.Add(122975, new CheckpointInfo(new uint256("2181671223c47b11f67512e3bc3040eb562da25d5fcbe33cb53d1862cb7bf0dc")));
             this.Checkpoints.Add(131039, new CheckpointInfo(new uint256("81aa79d04b430fc536592f4b6017fae8506869b84b208df655b3d4fe733f5204")));
             this.Checkpoints.Add(136082, new CheckpointInfo(new uint256("2755d2940a031cd27631ad9529ddc96bbbabb4bd0b34be2aa92f92c070d0d417")));
-
 
             this.Bech32Encoders = new Bech32Encoder[2];
             var encoder = new Bech32Encoder("rh");

--- a/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
@@ -82,7 +82,7 @@ namespace Blockcore.Networks.XRC
                 PowLimit2Time = 1541879606,
                 PowLimit2Height = 1648,
                 PowDigiShieldX11Height = 136135,
-                PowDigiShieldX11Time = 2541879606
+                PowDigiShieldX11Time = 1652082380
             };
 
             Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyMain);

--- a/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
@@ -81,7 +81,7 @@ namespace Blockcore.Networks.XRC
                 MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
                 PowLimit2Time = 1541879606,
                 PowLimit2Height = 1648,
-                PowDigiShieldX11Height = 10000000,
+                PowDigiShieldX11Height = 136135,
                 PowDigiShieldX11Time = 2541879606
             };
 
@@ -91,7 +91,7 @@ namespace Blockcore.Networks.XRC
             this.Consensus = new XRCConsensus(
                 consensusFactory: consensusFactory,
                 consensusOptions: consensusOptions,
-                coinType: 10291, 
+                coinType: (int)XRCCoinType.CoinTypes.XRCMain, 
                 hashGenesisBlock: genesisBlock.GetHash(), 
                 subsidyHalvingInterval: 210000, 
                 majorityEnforceBlockUpgrade: 750, 
@@ -100,9 +100,9 @@ namespace Blockcore.Networks.XRC
                 buriedDeployments: buriedDeployments,
                 bip9Deployments: new XRCBIP9Deployments(),
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),  
-                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing  
+                minerConfirmationWindow: 2016,  
                 maxReorgLength: 0, 
-                defaultAssumeValid: null, // 1600000 
+                defaultAssumeValid: null,
                 maxMoney: 2100000 * Money.COIN, 
                 coinbaseMaturity: 10, 
                 premineHeight: 1, 
@@ -139,16 +139,26 @@ namespace Blockcore.Networks.XRC
             this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
             this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 23 };
 
-            this.Checkpoints = new Dictionary<int, CheckpointInfo>
-            {
-                { 17,new CheckpointInfo(new uint256("2430c4151e10cdc5ccbdea56b909c7c37ab2a852d3e7fb908e0a32493e2ac706")) },
-                { 117, new CheckpointInfo(new uint256("bf3082be3b2da88187ebeb902548b41dbff3bcac6687352e0c47d902acd28e62"))},
-                { 400, new CheckpointInfo(new uint256("20cb04127f12c1ae7a04ee6dc4c7e36f4c85ee2038c92126b3fd537110d96595"))},
-                { 800, new CheckpointInfo(new uint256("df37ca401ecccfc6dedf68ab76a7161496ad93d47c2a474075efb3220e3f3526"))},
-                { 26800, new CheckpointInfo(new uint256("c4efd4b6fa294fd72ab6f614dd6705eea43d0a83cd03d597c3214eaaf857a4b6"))},
-                { 43034, new CheckpointInfo(new uint256("4df06bd483d2c4ccde5cd1efe3b2ea7d969c41e5923a74c2bba1656a41fc6891"))},
-                { 110000, new CheckpointInfo(new uint256("d1d1282681f20223a281393528e6c624539e60177ecb42ab4512555974ac7775"))},
-            };
+            this.Checkpoints = new Dictionary<int, CheckpointInfo>();
+            this.Checkpoints.Add(2015, new CheckpointInfo(new uint256("574605587514315bf8dac135c093a50e5982cb26e47ac78f2a712b9289f5cc7e")));
+            this.Checkpoints.Add(10079, new CheckpointInfo(new uint256("a960cf32c570de76b4a2035831608bf884c3b8dad7a6e77d6a40b5dcb7f84f5e")));
+            this.Checkpoints.Add(18143, new CheckpointInfo(new uint256("fb2df6739907716b4a9c20d45f7db968481b76d97a4bd279a14d19d4dad2a18a")));
+            this.Checkpoints.Add(26207, new CheckpointInfo(new uint256("90034dfe536ef2c692d9fad3fc95ea16d0b3a004cb23677eb0cc6ba51b38fc40")));
+            this.Checkpoints.Add(34271, new CheckpointInfo(new uint256("f8e3cf72102112a26a7af75fff195321226023a2e2617723b5c6259d63d419da")));
+            this.Checkpoints.Add(42335, new CheckpointInfo(new uint256("8bbeb434aba05f41ed2f4d4091289d7c6cd4f6e6168dfc207361b3b53d885970")));
+            this.Checkpoints.Add(50399, new CheckpointInfo(new uint256("07e3d655eb39be8e1297ff1835aa09ebe68ca2a1c31d9b412ac029f9066e75e1")));
+            this.Checkpoints.Add(58463, new CheckpointInfo(new uint256("88b714a59faa29037b1cf63eb35bcd243a60768bb2cc21cfb500c77fe67d3369")));
+            this.Checkpoints.Add(66527, new CheckpointInfo(new uint256("113d337fe7b6aa8d059a674bc339506fa9f69e0c390e978582253c6dd9dcd5b6")));
+            this.Checkpoints.Add(74591, new CheckpointInfo(new uint256("0ef81cb39624d5d0c5b0696aed93d97aac5cf342af569485b28ca1e2afb85afa")));
+            this.Checkpoints.Add(82655, new CheckpointInfo(new uint256("1254dc1e830853650c3ca41a7487510a632e85b8e8b31e4a87205edc0b373397")));
+            this.Checkpoints.Add(90719, new CheckpointInfo(new uint256("782ac4559002e425cc63fe71bb1cb89e03305cc1270d2846baa451d4d4bf9c43")));
+            this.Checkpoints.Add(98783, new CheckpointInfo(new uint256("53505abcda5dff8278113d67949b260ce6a79a01dd6b775e6cfc50619d7d0656")));
+            this.Checkpoints.Add(106847, new CheckpointInfo(new uint256("6661f25d3850a2cb95a2dd3c1eb7752a7ab9f780c745a8b8fd5ce9fba5acfdbf")));
+            this.Checkpoints.Add(114911, new CheckpointInfo(new uint256("f343f45fdff7bede9db8bb10ab1c00ebcd7c173823ef6e49e493ed86e71d2f27")));
+            this.Checkpoints.Add(122975, new CheckpointInfo(new uint256("2181671223c47b11f67512e3bc3040eb562da25d5fcbe33cb53d1862cb7bf0dc")));
+            this.Checkpoints.Add(131039, new CheckpointInfo(new uint256("81aa79d04b430fc536592f4b6017fae8506869b84b208df655b3d4fe733f5204")));
+            this.Checkpoints.Add(136082, new CheckpointInfo(new uint256("2755d2940a031cd27631ad9529ddc96bbbabb4bd0b34be2aa92f92c070d0d417")));
+
 
             this.Bech32Encoders = new Bech32Encoder[2];
             var encoder = new Bech32Encoder("rh");
@@ -159,7 +169,6 @@ namespace Blockcore.Networks.XRC
             {
                 new DNSSeedData("dns.btrmine.com", "dns.btrmine.com"),
                 new DNSSeedData("dns2.btrmine.com", "dns2.btrmine.com"),
-                new DNSSeedData("xrc.dnsseed.ekcdd.com", "xrc.dnsseed.ekcdd.com")
             };
 
             this.SeedNodes = new List<NetworkAddress>(); 

--- a/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCMain.cs
@@ -4,12 +4,6 @@ using Blockcore.Base.Deployments;
 using Blockcore.Consensus;
 using Blockcore.Consensus.BlockInfo;
 using Blockcore.Consensus.Checkpoints;
-using Blockcore.Consensus.ScriptInfo;
-using Blockcore.Consensus.TransactionInfo;
-using Blockcore.Features.Consensus.Rules.CommonRules;
-using Blockcore.Features.Consensus.Rules.UtxosetRules;
-using Blockcore.Features.MemoryPool.Rules;
-using Blockcore.Networks.XRC.Rules;
 using Blockcore.Networks.XRC.Consensus;
 using Blockcore.Networks.XRC.Deployments;
 using Blockcore.Networks.XRC.Policies;
@@ -20,20 +14,8 @@ using NBitcoin.Protocol;
 
 namespace Blockcore.Networks.XRC
 {
-    public class XRCMain : Network
+    public class XRCMain : XRCNetwork
     {
-        /// <summary> xRhodium maximal value for the calculated time offset. If the value is over this limit, the time syncing feature will be switched off. </summary>
-        public const int xRhodiumMaxTimeOffsetSeconds = 25 * 60;
-
-        /// <summary> xRhodium default value for the maximum tip age in seconds to consider the node in initial block download (2 hours). </summary>
-        public const int xRhodiumDefaultMaxTipAgeInSeconds = 604800;
-
-        /// <summary> The name of the root folder containing the different xRhodium blockchains (xRhodiumMain, xRhodiumTest, xRhodiumRegTest). </summary>
-        public const string xRhodiumRootFolderName = "xrhodium";
-
-        /// <summary> The default name used for the xRhodium configuration file. </summary>
-        public const string xRhodiumDefaultConfigFilename = "xrhodium.conf";
-
         public XRCMain()
         {
             // The message start string is designed to be unlikely to occur in normal data.
@@ -54,14 +36,14 @@ namespace Blockcore.Networks.XRC
             this.DefaultMaxInboundConnections = 109;
             this.DefaultRPCPort = 19660;
             this.DefaultAPIPort = 37221;
-            this.MaxTipAge = xRhodiumDefaultMaxTipAgeInSeconds;
+            this.MaxTipAge = 604800;
             this.MinTxFee = 1000;
             this.MaxTxFee = Money.Coins(1).Satoshi;
             this.FallbackFee = 20000;
             this.MinRelayTxFee = 1000;
-            this.RootFolderName = xRhodiumRootFolderName;
-            this.DefaultConfigFilename = xRhodiumDefaultConfigFilename;
-            this.MaxTimeOffsetSeconds = xRhodiumMaxTimeOffsetSeconds;
+            this.RootFolderName = "xrhodium";
+            this.DefaultConfigFilename = "xrhodium.conf";
+            this.MaxTimeOffsetSeconds = 25 * 60;
             this.CoinTicker = "XRC";
             this.DefaultBanTimeSeconds = 16000; // 500 (MaxReorg) * 64 (TargetSpacing) / 2 = 4 hours, 26 minutes and 40 seconds
 
@@ -73,11 +55,7 @@ namespace Blockcore.Networks.XRC
             this.GenesisBits = new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")).ToCompact();
             this.GenesisVersion = 45;
             this.GenesisReward = Money.Zero;
-
             var pubKeyMain = "04ffff0f1e01041a52656c6561736520746865204b72616b656e212121205a657573";
-            Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyMain);
-
-            this.Genesis = genesisBlock;
 
             var consensusOptions = new PosConsensusOptions
             {
@@ -97,11 +75,18 @@ namespace Blockcore.Networks.XRC
                 [BuriedDeployments.BIP66] = 0
             };
 
-            consensusFactory.Protocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new XRCConsensusProtocol()
             {
                 ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
                 MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+                PowLimit2Time = 1541879606,
+                PowLimit2Height = 1648,
+                PowDigiShieldX11Height = 10000000,
+                PowDigiShieldX11Time = 2541879606
             };
+
+            Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyMain);
+            this.Genesis = genesisBlock;
 
             this.Consensus = new XRCConsensus(
                 consensusFactory: consensusFactory,
@@ -130,8 +115,6 @@ namespace Blockcore.Networks.XRC
                 powNoRetargeting: false,
                 powLimit: new Target(new uint256("0000000000092489000000000000000000000000000000000000000000000000")),
                 powLimit2: new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
-                powLimit2Time: 1541879606,
-                powLimit2Height: 1648,
                 minimumChainWork: uint256.Zero,
                 isProofOfStake: false,
                 lastPowBlock: default(int),
@@ -184,97 +167,6 @@ namespace Blockcore.Networks.XRC
 
             this.RegisterRules(this.Consensus);
             this.RegisterMempoolRules(this.Consensus);
-        }
-
-        protected void RegisterRules(IConsensus consensus)
-        {
-            consensus.ConsensusRules
-                .Register<HeaderTimeChecksRule>()
-                .Register<XRCCheckDifficultyPowRule>()
-                .Register<XRCHeaderVersionRule>();
-
-            consensus.ConsensusRules
-                .Register<BlockMerkleRootRule>(); 
-
-            consensus.ConsensusRules
-                .Register<SetActivationDeploymentsPartialValidationRule>()
-
-                .Register<TransactionLocktimeActivationRule>()
-                .Register<CoinbaseHeightActivationRule>()
-                .Register<WitnessCommitmentsRule>()
-                .Register<BlockSizeRule>()
-
-                .Register<EnsureCoinbaseRule>()
-                .Register<CheckPowTransactionRule>()
-                .Register<CheckSigOpsRule>();
-
-            consensus.ConsensusRules
-                .Register<SetActivationDeploymentsFullValidationRule>()
-
-                // rules that require the store to be loaded (coinview)
-                .Register<FetchUtxosetRule>()
-                .Register<TransactionDuplicationActivationRule>()
-                .Register<CheckPowUtxosetPowRule>()
-                .Register<PushUtxosetRule>()
-                .Register<FlushUtxosetRule>();
-        }
-
-        protected void RegisterMempoolRules(IConsensus consensus)
-        {
-            consensus.MempoolRules = new List<Type>()
-            {
-                typeof(CheckConflictsMempoolRule),
-                typeof(CheckCoinViewMempoolRule),
-                typeof(CreateMempoolEntryMempoolRule),
-                typeof(CheckSigOpsMempoolRule),
-                typeof(CheckFeeMempoolRule),
-                typeof(CheckRateLimitMempoolRule),
-                typeof(CheckAncestorsMempoolRule),
-                typeof(CheckReplacementMempoolRule),
-                typeof(CheckAllInputsMempoolRule),
-                typeof(CheckTxOutDustRule)
-            };
-        }
-
-        public static Block CreateXRCGenesisBlock(ConsensusFactory consensusFactory, uint nTime, uint nNonce, uint nBits, int nVersion, string pubKey)
-        {
-            string message = "Release the Kraken!!! Zeus";
-            return CreateXRCGenesisBlock(consensusFactory, message, nTime, nNonce, nBits, nVersion, pubKey);
-        }
-
-        private static Block CreateXRCGenesisBlock(ConsensusFactory consensusFactory, string message, uint nTime, uint nNonce, uint nBits, int nVersion, string pubKey)
-        {
-            //nTime = 1512043200 => Thursday, November 30, 2017 12:00:00 PM (born XRC)
-            //nTime = 1527811200 => Friday, Jun 1, 2017 12:00:00 PM (born TestXRC)
-            //nBits = 0x1d00ffff (it is exactly 0x1b = 27 bytes long) => 0x00ffff0000000000000000000000000000000000000000000000000000 => 1
-            //nNonce = XTimes to trying to find a genesis block
-            Transaction txNew = consensusFactory.CreateTransaction();
-            txNew.Version = 2;
-            if (txNew is IPosTransactionWithTime posTx)
-                posTx.Time = nTime;
-            txNew.AddInput(new TxIn()
-            {
-                ScriptSig = new Script(Op.GetPushOp(nBits), new Op()
-                {
-                    Code = (OpcodeType)0x1,
-                    PushData = new[] { (byte)4 }
-                }, Op.GetPushOp(Encoders.ASCII.DecodeData(message)))
-            });
-            txNew.AddOutput(new TxOut()
-            {
-                Value = Money.Zero,
-                ScriptPubKey = Script.FromBytesUnsafe(Encoders.Hex.DecodeData(pubKey))
-            });
-
-            Block genesis = consensusFactory.CreateBlock();
-            genesis.Header.BlockTime = Utils.UnixTimeToDateTime(nTime);
-            genesis.Header.Bits = nBits;
-            genesis.Header.Nonce = nNonce;
-            genesis.Header.Version = nVersion;
-            genesis.Transactions.Add(txNew);
-            genesis.Header.HashPrevBlock = uint256.Zero;
-            genesis.UpdateMerkleRoot();
-            return genesis;
         }
     }
 }

--- a/src/Networks/Blockcore.Networks.XRC/XRCRegTest.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCRegTest.cs
@@ -92,7 +92,7 @@ namespace Blockcore.Networks.XRC
             this.Consensus = new XRCConsensus(
                 consensusFactory: consensusFactory,
                 consensusOptions: consensusOptions,
-                coinType: 1,
+                coinType: (int)XRCCoinType.CoinTypes.XRCReg,
                 hashGenesisBlock: genesisBlock.GetHash(),
                 subsidyHalvingInterval: 210000,
                 majorityEnforceBlockUpgrade: 750,
@@ -101,15 +101,15 @@ namespace Blockcore.Networks.XRC
                 buriedDeployments: buriedDeployments,
                 bip9Deployments: new XRCBIP9Deployments(),
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
-                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing  
+                minerConfirmationWindow: 2016,
                 maxReorgLength: 0,
-                defaultAssumeValid: null, // 1600000 
+                defaultAssumeValid: null,
                 maxMoney: 2100000 * Money.COIN,
                 coinbaseMaturity: 6,
                 premineHeight: 1,
                 premineReward: new Money(1050000 * Money.COIN),
                 proofOfWorkReward: Money.Coins((decimal)2.5),
-                targetTimespan: TimeSpan.FromSeconds(14 * 24 * 60 * 60), // two weeks
+                targetTimespan: TimeSpan.FromSeconds(14 * 24 * 60 * 60),
                 targetSpacing: TimeSpan.FromSeconds(10 * 60),
                 powAllowMinDifficultyBlocks: true,
                 posNoRetargeting: true,

--- a/src/Networks/Blockcore.Networks.XRC/XRCRegTest.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCRegTest.cs
@@ -14,7 +14,7 @@ using NBitcoin.Protocol;
 
 namespace Blockcore.Networks.XRC
 {
-    public class XRCRegTest : XRCMain
+    public class XRCRegTest : XRCNetwork
     {
         public XRCRegTest()
         {
@@ -36,14 +36,14 @@ namespace Blockcore.Networks.XRC
             this.DefaultMaxInboundConnections = 109;
             this.DefaultRPCPort = 16661;
             this.DefaultAPIPort = 16669;
-            this.MaxTipAge = xRhodiumDefaultMaxTipAgeInSeconds;
+            this.MaxTipAge = 604800;
             this.MinTxFee = 1000;
             this.MaxTxFee = Money.Coins(1).Satoshi;
             this.FallbackFee = 20000;
             this.MinRelayTxFee = 1000;
-            this.RootFolderName = xRhodiumRootFolderName;
-            this.DefaultConfigFilename = xRhodiumDefaultConfigFilename;
-            this.MaxTimeOffsetSeconds = xRhodiumMaxTimeOffsetSeconds;
+            this.RootFolderName = "xrhodium";
+            this.DefaultConfigFilename = "xrhodium.conf";
+            this.MaxTimeOffsetSeconds = 25 * 60;
             this.CoinTicker = "XRC";
             this.DefaultBanTimeSeconds = 16000; // 500 (MaxReorg) * 64 (TargetSpacing) / 2 = 4 hours, 26 minutes and 40 seconds
 
@@ -57,9 +57,6 @@ namespace Blockcore.Networks.XRC
             this.GenesisReward = Money.Zero;
 
             var pubKeyMain = "2103d1b6cd5f956ccedf5877c89843a438bfb800468133fb2e73946e1452461a9b1aac";
-            Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyMain);
-
-            this.Genesis = genesisBlock;
 
             var consensusOptions = new PosConsensusOptions
             {
@@ -79,11 +76,18 @@ namespace Blockcore.Networks.XRC
                 [BuriedDeployments.BIP66] = 0
             };
 
-            consensusFactory.Protocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new XRCConsensusProtocol()
             {
                 ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
                 MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+                PowLimit2Time = 0,
+                PowLimit2Height = 0,
+                PowDigiShieldX11Height = 0,
+                PowDigiShieldX11Time = 0
             };
+
+            Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyMain);
+            this.Genesis = genesisBlock;
 
             this.Consensus = new XRCConsensus(
                 consensusFactory: consensusFactory,
@@ -112,8 +116,6 @@ namespace Blockcore.Networks.XRC
                 powNoRetargeting: false,
                 powLimit: new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
                 powLimit2: new Target(new uint256("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
-                powLimit2Time: 0,
-                powLimit2Height: 0,
                 minimumChainWork: uint256.Zero,
                 isProofOfStake: false,
                 lastPowBlock: default(int),

--- a/src/Networks/Blockcore.Networks.XRC/XRCTest.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCTest.cs
@@ -45,11 +45,10 @@ namespace Blockcore.Networks.XRC
             this.DefaultConfigFilename = "xrhodium.conf";
             this.MaxTimeOffsetSeconds = 25 * 60;
             this.CoinTicker = "XRC";
-            this.DefaultBanTimeSeconds = 16000; // 500 (MaxReorg) * 64 (TargetSpacing) / 2 = 4 hours, 26 minutes and 40 seconds
+            this.DefaultBanTimeSeconds = 16000; 
 
             var consensusFactory = new XRCConsensusFactory();
 
-            // Create the genesis block.
             this.GenesisTime = 1527811200;
             this.GenesisNonce = 0;
             this.GenesisBits = new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")).ToCompact();
@@ -82,7 +81,7 @@ namespace Blockcore.Networks.XRC
                 PowLimit2Time = 0,
                 PowLimit2Height = 0,
                 PowDigiShieldX11Height = 16290,
-                PowDigiShieldX11Time = 1648674952
+                PowDigiShieldX11Time = 1651753185
             };
 
             Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyTest);
@@ -91,7 +90,7 @@ namespace Blockcore.Networks.XRC
             this.Consensus = new XRCConsensus(
                 consensusFactory: consensusFactory,
                 consensusOptions: consensusOptions,
-                coinType: 1,
+                coinType: (int)XRCCoinType.CoinTypes.XRCTest,
                 hashGenesisBlock: genesisBlock.GetHash(),
                 subsidyHalvingInterval: 210000,
                 majorityEnforceBlockUpgrade: 750,

--- a/src/Networks/Blockcore.Networks.XRC/XRCTest.cs
+++ b/src/Networks/Blockcore.Networks.XRC/XRCTest.cs
@@ -14,7 +14,7 @@ using NBitcoin.Protocol;
 
 namespace Blockcore.Networks.XRC
 {
-    public class XRCTest : XRCMain
+    public class XRCTest : XRCNetwork
     {
         public XRCTest()
         {
@@ -36,14 +36,14 @@ namespace Blockcore.Networks.XRC
             this.DefaultMaxInboundConnections = 109;
             this.DefaultRPCPort = 16661;
             this.DefaultAPIPort = 16669;
-            this.MaxTipAge = xRhodiumDefaultMaxTipAgeInSeconds;
+            this.MaxTipAge = 604800;
             this.MinTxFee = 10000;
             this.MaxTxFee = Money.Coins(1).Satoshi;
             this.FallbackFee = 60000;
             this.MinRelayTxFee = 10000;
-            this.RootFolderName = xRhodiumRootFolderName;
-            this.DefaultConfigFilename = xRhodiumDefaultConfigFilename;
-            this.MaxTimeOffsetSeconds = xRhodiumMaxTimeOffsetSeconds;
+            this.RootFolderName = "xrhodium";
+            this.DefaultConfigFilename = "xrhodium.conf";
+            this.MaxTimeOffsetSeconds = 25 * 60;
             this.CoinTicker = "XRC";
             this.DefaultBanTimeSeconds = 16000; // 500 (MaxReorg) * 64 (TargetSpacing) / 2 = 4 hours, 26 minutes and 40 seconds
 
@@ -55,11 +55,7 @@ namespace Blockcore.Networks.XRC
             this.GenesisBits = new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")).ToCompact();
             this.GenesisVersion = 45;
             this.GenesisReward = Money.Zero;
-            
             var pubKeyTest = "04ffff0f1e01041a52656c6561736520746865204b72616b656e212121205a657573";
-            Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyTest);
-
-            this.Genesis = genesisBlock;
 
             var consensusOptions = new PosConsensusOptions
             {
@@ -79,11 +75,18 @@ namespace Blockcore.Networks.XRC
                 [BuriedDeployments.BIP66] = 0
             };
 
-            consensusFactory.Protocol = new ConsensusProtocol()
+            consensusFactory.Protocol = new XRCConsensusProtocol()
             {
                 ProtocolVersion = ProtocolVersion.FEEFILTER_VERSION,
                 MinProtocolVersion = ProtocolVersion.POS_PROTOCOL_VERSION,
+                PowLimit2Time = 0,
+                PowLimit2Height = 0,
+                PowDigiShieldX11Height = 16290,
+                PowDigiShieldX11Time = 1648674952
             };
+
+            Block genesisBlock = CreateXRCGenesisBlock(consensusFactory, this.GenesisTime, this.GenesisNonce, this.GenesisBits, this.GenesisVersion, pubKeyTest);
+            this.Genesis = genesisBlock;
 
             this.Consensus = new XRCConsensus(
                 consensusFactory: consensusFactory,
@@ -112,8 +115,6 @@ namespace Blockcore.Networks.XRC
                 powNoRetargeting: false,
                 powLimit: new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
                 powLimit2: new Target(new uint256("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
-                powLimit2Time: 0,
-                powLimit2Height: 0,
                 minimumChainWork: uint256.Zero,
                 isProofOfStake: false,
                 lastPowBlock: default(int),


### PR DESCRIPTION
Hello,
there was a new hardfork of XRC from block 136136 which changed algo of XRC from X13 to X11 and it is using now DigiShield POW Retarget every next block.

This pull request is there because of compatibility of Blockcore with this change.

Thank you for merge.