### PR TITLE
Fix wallet to use segwit in the correct derivation path

### DIFF
--- a/src/Features/Blockcore.Features.ColdStaking/Api/Controllers/ColdStakingController.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/Api/Controllers/ColdStakingController.cs
@@ -148,7 +148,7 @@ namespace Blockcore.Features.ColdStaking.Api.Controllers
 
                 var model = new GetColdStakingAddressResponse
                 {
-                    Address = request.Segwit ? address?.Bech32Address : address?.Address
+                    Address = address?.Address
                 };
 
                 if (model.Address == null)
@@ -213,7 +213,7 @@ namespace Blockcore.Features.ColdStaking.Api.Controllers
 
                 Transaction transaction = this.ColdStakingManager.GetColdStakingSetupTransaction(
                     this.walletTransactionHandler, request.ColdWalletAddress, request.HotWalletAddress,
-                    request.WalletName, request.WalletAccount, request.WalletPassword, amount, feeAmount, request.SegwitChangeAddress, request.PayToScript, createHotAccount);
+                    request.WalletName, request.WalletAccount, request.WalletPassword, amount, feeAmount, request.PayToScript, createHotAccount);
 
                 var model = new SetupColdStakingResponse
                 {

--- a/src/Features/Blockcore.Features.ColdStaking/Api/Models/ColdStakingModels.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/Api/Models/ColdStakingModels.cs
@@ -242,11 +242,6 @@ namespace Blockcore.Features.ColdStaking.Api.Models
         public string Fees { get; set; }
 
         /// <summary>
-        /// Whether to send the change to a P2WPKH (segwit bech32) addresses, or a regular P2PKH address
-        /// </summary>
-        public bool SegwitChangeAddress { get; set; }
-
-        /// <summary>
         /// Use script outputs (P2SH and P2WSH) for cold staking
         /// </summary>
         public bool PayToScript { get; set; }

--- a/src/Features/Blockcore.Features.ColdStaking/Api/Models/ColdStakingModels.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/Api/Models/ColdStakingModels.cs
@@ -108,11 +108,6 @@ namespace Blockcore.Features.ColdStaking.Api.Models
         [JsonProperty(PropertyName = "isColdWalletAddress")]
         public bool IsColdWalletAddress { get; set; }
 
-        /// <summary>
-        /// Whether to return the P2WPKH (segwit bech32) addresses, or a regular P2PKH address
-        /// </summary>
-        public bool Segwit { get; set; }
-
         /// <summary>Creates a string containing the properties of this object.</summary>
         /// <returns>A string containing the properties of the object.</returns>
         public override string ToString()

--- a/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
@@ -240,7 +240,11 @@ namespace Blockcore.Features.ColdStaking
                 accountName = HotWalletAccountName;
             }
 
-            account = wallet.AddNewAccount(walletPassword, this.dateTimeProvider.GetTimeOffset(), accountIndex, accountName);
+            // TODO: coldtake account in initially used the BIP44 purpose field
+            // This should have probably been allocated a new purpose field and not a new account indexer field
+            // We should investigate the amount of effort required to move to a purpose field instead of account index
+            int bip44Purpose = 44;
+            account = wallet.AddNewAccount(walletPassword, this.dateTimeProvider.GetTimeOffset(), bip44Purpose, accountIndex, accountName);
 
             // Maintain at least one unused address at all times. This will ensure that wallet recovery will also work.
             IEnumerable<HdAddress> newAddresses = account.CreateAddresses(wallet.Network, 1, false);
@@ -258,9 +262,9 @@ namespace Blockcore.Features.ColdStaking
         /// track addresses under the <see cref="ColdWalletAccountIndex"/> HD account.
         /// </summary>
         /// <inheritdoc />
-        public override Wallet.Types.Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase, int? coinType = null, bool? isColdStakingWallet = false)
+        public override Wallet.Types.Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase, int? purpose = null, int? coinType = null, bool? isColdStakingWallet = false)
         {
-            Wallet.Types.Wallet wallet = base.RecoverWallet(password, name, mnemonic, creationTime, passphrase, coinType);
+            Wallet.Types.Wallet wallet = base.RecoverWallet(password, name, mnemonic, creationTime, passphrase, purpose, coinType);
 
             if (isColdStakingWallet.HasValue && isColdStakingWallet == true)
             {
@@ -531,7 +535,7 @@ namespace Blockcore.Features.ColdStaking
             {
                 AccountReference = accountReference,
                 // Specify a dummy change address to prevent a change (internal) address from being created.
-                // Will be changed after the transacton is built and before it is signed.
+                // Will be changed after the transaction is built and before it is signed.
                 ChangeAddress = coldAccount.ExternalAddresses.First(),
                 TransactionFee = feeAmount,
                 MinConfirmations = 0,

--- a/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
@@ -240,11 +240,16 @@ namespace Blockcore.Features.ColdStaking
                 accountName = HotWalletAccountName;
             }
 
-            // TODO: coldtake account in initially used the BIP44 purpose field
-            // This should have probably been allocated a new purpose field and not a new account indexer field
-            // We should investigate the amount of effort required to move to a purpose field instead of account index
-            int bip44Purpose = 44;
-            account = wallet.AddNewAccount(walletPassword, this.dateTimeProvider.GetTimeOffset(), bip44Purpose, accountIndex, accountName);
+            HdAccount defaultAccount =  wallet.GetAccount(0);
+            int purposeField = defaultAccount.Purpose;
+
+            //if (wallet.Version < 2)
+            //{
+            //    // to maintain backwards compatibility we default to bip44 for old wallets.
+            //    purposeField = 44;
+            //}
+
+            account = wallet.AddNewAccount(walletPassword, this.dateTimeProvider.GetTimeOffset(), purposeField, accountIndex, accountName);
 
             // Maintain at least one unused address at all times. This will ensure that wallet recovery will also work.
             IEnumerable<HdAddress> newAddresses = account.CreateAddresses(wallet.Network, 1, false);

--- a/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
+++ b/src/Features/Blockcore.Features.ColdStaking/ColdStakingManager.cs
@@ -243,12 +243,6 @@ namespace Blockcore.Features.ColdStaking
             HdAccount defaultAccount =  wallet.GetAccount(0);
             int purposeField = defaultAccount.Purpose;
 
-            //if (wallet.Version < 2)
-            //{
-            //    // to maintain backwards compatibility we default to bip44 for old wallets.
-            //    purposeField = 44;
-            //}
-
             account = wallet.AddNewAccount(walletPassword, this.dateTimeProvider.GetTimeOffset(), purposeField, accountIndex, accountName);
 
             // Maintain at least one unused address at all times. This will ensure that wallet recovery will also work.
@@ -391,10 +385,8 @@ namespace Blockcore.Features.ColdStaking
             KeyId coldPubKeyHash = null;
 
             // Check if this is a segwit address
-            //if (coldAddress?.Bech32Address == coldWalletAddress || hotAddress?.Bech32Address == hotWalletAddress)
             if ((coldAddress != null && coldAddress.IsBip84()) || (hotAddress != null && hotAddress.IsBip84()))
             {
-                //TODO: check that both hot and cold address are same (segwit or none segwit and throw if not)
                 hotPubKeyHash = new BitcoinWitPubKeyAddress(hotWalletAddress, wallet.Network).Hash.AsKeyId();
                 coldPubKeyHash = new BitcoinWitPubKeyAddress(coldWalletAddress, wallet.Network).Hash.AsKeyId();
                 destination = ColdStakingScriptTemplate.Instance.GenerateScriptPubKey(hotPubKeyHash, coldPubKeyHash);

--- a/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeDelegate.razor
+++ b/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeDelegate.razor
@@ -159,8 +159,6 @@
 
     private decimal Fee { get; set; }
 
-    public bool SegwitChangeAddress { get; set; }
-
     public bool PayToScript { get; set; }
 
     protected override Task OnInitializedAsync()
@@ -202,8 +200,6 @@
                 this.Alert = "Segwit is not activated, can't use segwit address.";
                 return;
             }
-
-            this.SegwitChangeAddress = true;
         }
         else
         {
@@ -223,12 +219,6 @@
         if (address == null)
         {
             this.Alert = "The cold staking account does not exist.";
-            return;
-        }
-
-        if (this.SegwitChangeAddress != address.IsBip84())
-        {
-            this.Alert = "Trying to send to a segwit address from a non segwit wallet.";
             return;
         }
 
@@ -252,7 +242,6 @@
                 this.Password,
                 new Money(this.Amount, MoneyUnit.BTC),
                 new Money(this.Fee, MoneyUnit.BTC),
-                this.SegwitChangeAddress,
                 this.PayToScript);
 
             await this.BroadcasterManager.BroadcastTransactionAsync(transaction);

--- a/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeDelegate.razor
+++ b/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeDelegate.razor
@@ -232,7 +232,7 @@
             return;
         }
 
-        this.ColdWalletAddress = this.SegwitChangeAddress ? address?.Bech32Address : address?.Address;
+        this.ColdWalletAddress = address?.Address;
         if (this.ColdWalletAddress == null)
         {
             this.Alert = "The cold staking account does not exist.";

--- a/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeSetup.razor
+++ b/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeSetup.razor
@@ -179,8 +179,6 @@
 
     private decimal Fee { get; set; }
 
-    public bool SegwitChangeAddress { get; set; }
-
     public bool PayToScript { get; set; }
 
     protected override Task OnInitializedAsync()
@@ -191,10 +189,7 @@
 
         var address = this.ColdStakingManager.GetFirstUnusedColdStakingAddress(this.walletname, true);
 
-        // this.SegwitChangeAddress = this.NodeDeployments.GetFlags().ScriptFlags.HasFlag(ScriptVerify.Witness);
-        this.SegwitChangeAddress = address.IsBip84();
-
-        this.ColdWalletAddress = this.SegwitChangeAddress ? address?.Bech32Address : address?.Address;
+        this.ColdWalletAddress = address?.Address;
 
         if (this.ColdWalletAddress == null)
         {
@@ -209,7 +204,7 @@
     {
         var address = this.ColdStakingManager.GetFirstUnusedColdStakingAddress(hotWalletName, false);
 
-        this.HotWalletAddress = this.SegwitChangeAddress ? address?.Bech32Address : address?.Address;
+        this.HotWalletAddress = address?.Address;
 
         if (this.HotWalletAddress == null)
         {
@@ -261,7 +256,6 @@
                 this.Password,
                 new Money(this.Amount, MoneyUnit.BTC),
                 new Money(this.Fee, MoneyUnit.BTC),
-                this.SegwitChangeAddress,
                 this.PayToScript);
 
             await this.BroadcasterManager.BroadcastTransactionAsync(transaction);

--- a/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeWithdraw.razor
+++ b/src/Features/Blockcore.Features.ColdStaking/UI/Pages/ColdStakeWithdraw.razor
@@ -180,9 +180,7 @@
     {
         var result = this.WalletManager.GetUnusedAddress(new Wallet.Types.WalletAccountReference(this.walletname, "account 0"));
 
-        var segwit = this.NodeDeployments.GetFlags().ScriptFlags.HasFlag(ScriptVerify.Witness);
-
-        this.Address = segwit ? result.Bech32Address : result.Address;
+        this.Address = result.Address;
     }
     public void MaxAmount()
     {

--- a/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
+++ b/src/Features/Blockcore.Features.Miner/Api/Controllers/StakingController.cs
@@ -206,7 +206,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
                 {
                     foreach (HdAddress address in account.GetCombinedAddresses())
                     {
-                        if ((address.Address == request.Address) || address.Bech32Address == request.Address)
+                        if ((address.Address == request.Address))
                         {
                             address.StakingExpiry = request.StakingExpiry;
                         }
@@ -272,7 +272,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
                         {
                             addressItem = new GetStakingAddressesModelItem
                             {
-                                Addresses = request.Segwit ? address.Bech32Address : address.Address,
+                                Addresses = address.Address,
                                 Expiry = address.StakingExpiry,
                                 Expired = address.StakingExpiry < DateTime.UtcNow,
                             };
@@ -288,7 +288,7 @@ namespace Blockcore.Features.Miner.Api.Controllers
                                 {
                                     addressItem = new GetStakingAddressesModelItem
                                     {
-                                        Addresses = request.Segwit ? address.Bech32Address : address.Address,
+                                        Addresses = address.Address,
                                         Expiry = address.StakingExpiry,
                                         Expired = address.StakingExpiry < DateTime.UtcNow,
                                     };

--- a/src/Features/Blockcore.Features.Miner/Api/Models/RequestModels.cs
+++ b/src/Features/Blockcore.Features.Miner/Api/Models/RequestModels.cs
@@ -92,7 +92,5 @@ namespace Blockcore.Features.Miner.Api.Models
         /// </summary>
         [Required(ErrorMessage = "Name of wallet.")]
         public string WalletName { get; set; }
-
-        public bool Segwit { get; set; }
     }
 }

--- a/src/Features/Blockcore.Features.RPC/RPCClient.cs
+++ b/src/Features/Blockcore.Features.RPC/RPCClient.cs
@@ -1403,11 +1403,11 @@ namespace Blockcore.Features.RPC
         /// <param name="commentTx">A locally-stored (not broadcast) comment assigned to this transaction. Default is no comment</param>
         /// <param name="commentDest">A locally-stored (not broadcast) comment assigned to this transaction. Meant to be used for describing who the payment was sent to. Default is no comment</param>
         /// <returns>The TXID of the sent transaction</returns>
-        public uint256 SendToAddress(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal? fee = null, bool isSegwit = false)
+        public uint256 SendToAddress(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal? fee = null)
         {
             uint256 txid = null;
 
-            txid = SendToAddressAsync(address, amount, commentTx, commentDest, fee, isSegwit).GetAwaiter().GetResult();
+            txid = SendToAddressAsync(address, amount, commentTx, commentDest, fee).GetAwaiter().GetResult();
             return txid;
         }
 
@@ -1419,7 +1419,7 @@ namespace Blockcore.Features.RPC
         /// <param name="commentTx">A locally-stored (not broadcast) comment assigned to this transaction. Default is no comment</param>
         /// <param name="commentDest">A locally-stored (not broadcast) comment assigned to this transaction. Meant to be used for describing who the payment was sent to. Default is no comment</param>
         /// <returns>The TXID of the sent transaction</returns>
-        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal? fee = null, bool isSegwit = false)
+        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null, decimal? fee = null)
         {
             var parameters = new List<object>();
             parameters.Add(address.ToString());
@@ -1433,9 +1433,6 @@ namespace Blockcore.Features.RPC
 
             if (fee != null)
                 parameters.Add(fee.ToString());
-
-            if (isSegwit)
-                parameters.Add(isSegwit.ToString());
 
             RPCResponse resp = await SendCommandAsync(RPCOperations.sendtoaddress, parameters.ToArray()).ConfigureAwait(false);
             return uint256.Parse(resp.Result.ToString());

--- a/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletController.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletController.cs
@@ -751,7 +751,6 @@ namespace Blockcore.Features.Wallet.Api.Controllers
                     AllowOtherInputs = false,
                     Recipients = recipients,
                     ChangeAddress = changeAddress,
-                    UseSegwitChangeAddress = request.SegwitChangeAddress
                 };
 
                 if (!string.IsNullOrEmpty(request.FeeType))
@@ -1018,7 +1017,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
             try
             {
                 HdAddress result = this.walletManager.GetUnusedAddress(new WalletAccountReference(request.WalletName, request.AccountName));
-                return this.Json(request.Segwit ? result.Bech32Address : result.Address);
+                return this.Json(result.Address);
             }
             catch (Exception e)
             {
@@ -1051,7 +1050,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
             try
             {
                 IEnumerable<HdAddress> result = this.walletManager.GetUnusedAddresses(new WalletAccountReference(request.WalletName, request.AccountName), count);
-                return this.Json(result.Select(x => request.Segwit ? x.Bech32Address : x.Address).ToArray());
+                return this.Json(result.Select(x => x.Address).ToArray());
             }
             catch (Exception e)
             {
@@ -1093,7 +1092,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
                         return new AddressModel
                         {
-                            Address = request.Segwit ? address.Bech32Address : address.Address,
+                            Address = address.Address,
                             IsUsed = anyTrx,
                             IsChange = address.IsChangeAddress(),
                             AmountConfirmed = confirmedAmount,

--- a/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletController.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletController.cs
@@ -128,7 +128,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
             {
                 Mnemonic requestMnemonic = string.IsNullOrEmpty(request.Mnemonic) ? null : new Mnemonic(request.Mnemonic);
 
-                Mnemonic mnemonic = this.walletManager.CreateWallet(request.Password, request.Name, request.Passphrase, mnemonic: requestMnemonic);
+                Mnemonic mnemonic = this.walletManager.CreateWallet(request.Password, request.Name, request.Passphrase, mnemonic: requestMnemonic, purpose: request.Purpose);
 
                 // start syncing the wallet from the creation date
                 this.walletSyncManager.SyncFromDate(this.dateTimeProvider.GetUtcNow());
@@ -264,7 +264,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
             try
             {
-                Types.Wallet wallet = this.walletManager.RecoverWallet(request.Password, request.Name, request.Mnemonic, request.CreationDate, passphrase: request.Passphrase, request.CoinType, request.IsColdStakingWallet);
+                Types.Wallet wallet = this.walletManager.RecoverWallet(request.Password, request.Name, request.Mnemonic, request.CreationDate, passphrase: request.Passphrase, purpose: request.Purpose, request.CoinType, request.IsColdStakingWallet);
 
                 this.SyncFromBestHeightForRecoveredWallets(request.CreationDate);
 
@@ -314,8 +314,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
                         ? request.ExtPubKey
                         : LegacyExtPubKeyConverter.ConvertIfInLegacyStratisFormat(request.ExtPubKey, this.network);
 
-                this.walletManager.RecoverWallet(request.Name, ExtPubKey.Parse(accountExtPubKey), request.AccountIndex,
-                    request.CreationDate);
+                this.walletManager.RecoverWallet(request.Name, ExtPubKey.Parse(accountExtPubKey), request.AccountIndex, request.CreationDate, request.Purpose);
 
                 this.SyncFromBestHeightForRecoveredWallets(request.CreationDate);
 
@@ -951,7 +950,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
             try
             {
-                HdAccount result = this.walletManager.GetUnusedAccount(request.WalletName, request.Password);
+                HdAccount result = this.walletManager.GetUnusedAccount(request.WalletName, request.Password, request.Purpose);
                 return this.Json(result.Name);
             }
             catch (CannotAddAccountToXpubKeyWalletException e)

--- a/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletModelBuilder.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletModelBuilder.cs
@@ -172,7 +172,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
                 if (!string.IsNullOrEmpty(request.Address))
                 {
-                    query = query.Where(x => x.Address.Address == request.Address || x.Address.Bech32Address == request.Address);
+                    query = query.Where(x => x.Address.Address == request.Address);
                 }
 
                 // Sorting the history items by descending dates. That includes received and sent dates.

--- a/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletRPCController.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Controllers/WalletRPCController.cs
@@ -125,7 +125,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
         [ActionName("sendtoaddress")]
         [ActionDescription("Sends money to an address. Requires wallet to be unlocked using walletpassphrase.")]
-        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, decimal amount, string commentTx, string commentDest, decimal? fee = null, bool isSegwit = false)
+        public async Task<uint256> SendToAddressAsync(BitcoinAddress address, decimal amount, string commentTx, string commentDest, decimal? fee = null)
         {
             decimal transactionFee = fee ?? Money.Satoshis(this.FullNode.Network.MinTxFee).ToDecimal(MoneyUnit.BTC);
 
@@ -135,7 +135,6 @@ namespace Blockcore.Features.Wallet.Api.Controllers
                 Recipients = new[] { new Recipient { Amount = Money.Coins(amount), ScriptPubKey = address.ScriptPubKey } }.ToList(),
                 CacheSecret = false,
                 TransactionFee = Money.Coins(transactionFee),
-                UseSegwitChangeAddress = isSegwit
             };
 
             try
@@ -223,9 +222,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
 
             HdAddress hdAddress = this.walletManager.GetUnusedAddresses(accountReference, 1, alwaysnew: true).Single();
 
-            string address = hdAddress.Address; // legacy address
-            if (addressType != null && addressType.Equals("bech32", StringComparison.InvariantCultureIgnoreCase))
-                address = hdAddress.Bech32Address;
+            string address = hdAddress.Address;
 
             return new NewAddressModel(address);
         }
@@ -252,9 +249,7 @@ namespace Blockcore.Features.Wallet.Api.Controllers
             }
             HdAddress hdAddress = this.walletManager.GetUnusedAddress(this.GetWalletAccountReference());
 
-            string address = hdAddress.Address; // legacy address
-            if (addressType != null && addressType.Equals("bech32", StringComparison.InvariantCultureIgnoreCase))
-                address = hdAddress.Bech32Address;
+            string address = hdAddress.Address;
 
             return new NewAddressModel(address);
         }

--- a/src/Features/Blockcore.Features.Wallet/Api/Models/RequestModels.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Models/RequestModels.cs
@@ -68,6 +68,7 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// <summary>
         /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
         /// </summary>
+        [EnumDataType(typeof(BIP44Purpose),ErrorMessage = "The Purpose must be 44 (legacy) or 84 (segwit)")]
         public int? Purpose { get; set; }
     }
 
@@ -133,6 +134,7 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// <summary>
         /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
         /// </summary>
+        [EnumDataType(typeof(BIP44Purpose), ErrorMessage = "The Purpose must be 44 (legacy) or 84 (segwit)")]
         public int? Purpose { get; set; }
 
         /// <summary>
@@ -183,7 +185,7 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// <summary>
         /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
         /// </summary>
-        [EnumDataType(typeof(BIP44Purpose))]
+        [EnumDataType(typeof(BIP44Purpose), ErrorMessage = "The Purpose must be 44 (legacy) or 84 (segwit)")]
         public int? Purpose { get; set; }
     }
 
@@ -720,7 +722,7 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// <summary>
         /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
         /// </summary>
-        [EnumDataType(typeof(BIP44Purpose))]
+        [EnumDataType(typeof(BIP44Purpose), ErrorMessage = "The Purpose must be 44 (legacy) or 84 (segwit)")]
         public int? Purpose { get; set; }
     }
 

--- a/src/Features/Blockcore.Features.Wallet/Api/Models/RequestModels.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Models/RequestModels.cs
@@ -422,11 +422,6 @@ namespace Blockcore.Features.Wallet.Api.Models
         [Required(ErrorMessage = "A password is required.")]
         public string Password { get; set; }
 
-        /// <summary>
-        /// Whether to send the change to a P2WPKH (segwit bech32) addresses, or a regular P2PKH address
-        /// </summary>
-        public bool SegwitChangeAddress { get; set; }
-
         /// <inheritdoc />
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
@@ -575,11 +570,6 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// The name of the account for which to get the address.
         /// </summary>
         public string AccountName { get; set; }
-
-        /// <summary>
-        /// Whether to return the P2WPKH (segwit bech32) addresses, or a regular P2PKH address
-        /// </summary>
-        public bool Segwit { get; set; }
     }
 
     /// <summary>
@@ -608,11 +598,6 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// </summary>
         [Required]
         public string Count { get; set; }
-
-        /// <summary>
-        /// Whether to return the P2WPKH (segwit bech32) addresses, or a regular P2PKH address
-        /// </summary>
-        public bool Segwit { get; set; }
     }
 
     /// <summary>
@@ -635,11 +620,6 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// The name of the account for which to get the addresses.
         /// </summary>
         public string AccountName { get; set; }
-
-        /// <summary>
-        /// Whether to return the P2WPKH (segwit bech32) addresses, or a regular P2PKH address
-        /// </summary>
-        public bool Segwit { get; set; }
     }
 
     /// <summary>

--- a/src/Features/Blockcore.Features.Wallet/Api/Models/RequestModels.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Models/RequestModels.cs
@@ -64,6 +64,11 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// </summary>
         [Required(ErrorMessage = "The name of the wallet to create is missing.")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
+        /// </summary>
+        public int? Purpose { get; set; }
     }
 
     /// <summary>
@@ -126,9 +131,20 @@ namespace Blockcore.Features.Wallet.Api.Models
         public int? CoinType { get; set; }
 
         /// <summary>
+        /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
+        /// </summary>
+        public int? Purpose { get; set; }
+
+        /// <summary>
         /// Optional flag that indicates if the "coldStakingColdAddresses" and "coldStakingHotAddresses" accounts should be restored.
         /// </summary>
         public bool? IsColdStakingWallet { get; set; }
+    }
+
+    public enum BIP44Purpose
+    {
+        Bip44 = 44,
+        Bip84 = 84,
     }
 
     /// <summary>
@@ -163,6 +179,12 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// </summary>
         [JsonConverter(typeof(IsoDateTimeConverter))]
         public DateTime CreationDate { get; set; }
+
+        /// <summary>
+        /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
+        /// </summary>
+        [EnumDataType(typeof(BIP44Purpose))]
+        public int? Purpose { get; set; }
     }
 
     /// <summary>
@@ -694,6 +716,12 @@ namespace Blockcore.Features.Wallet.Api.Models
         /// </summary>
         [Required]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Optional BIP44 Purpose field, this can be either 44 or 48 (default to 44).
+        /// </summary>
+        [EnumDataType(typeof(BIP44Purpose))]
+        public int? Purpose { get; set; }
     }
 
     /// <summary>

--- a/src/Features/Blockcore.Features.Wallet/Api/Models/SpendableTransactionsModel.cs
+++ b/src/Features/Blockcore.Features.Wallet/Api/Models/SpendableTransactionsModel.cs
@@ -39,6 +39,12 @@ namespace Blockcore.Features.Wallet.Api.Models
         public string Address { get; set; }
 
         /// <summary>
+        /// The script.
+        /// </summary>
+        [JsonProperty(PropertyName = "script")]
+        public string Script { get; set; }
+
+        /// <summary>
         /// A value indicating whether this address is a change address.
         /// </summary>
         [JsonProperty(PropertyName = "isChange")]

--- a/src/Features/Blockcore.Features.Wallet/Helpers/HdOperations.cs
+++ b/src/Features/Blockcore.Features.Wallet/Helpers/HdOperations.cs
@@ -57,15 +57,16 @@ namespace Blockcore.Features.Wallet.Helpers
         /// </summary>
         /// <param name="privateKey">The private key from which to generate the extended public key.</param>
         /// <param name="chainCode">The chain code used in creating the extended public key.</param>
+        /// <param name="purpose">Purpose of the coin this account is in.</param>
         /// <param name="coinType">Type of the coin of the account for which to generate an extended public key.</param>
         /// <param name="accountIndex">Index of the account for which to generate an extended public key.</param>
         /// <returns>The extended public key for an account, used to derive child keys.</returns>
-        public static ExtPubKey GetExtendedPublicKey(Key privateKey, byte[] chainCode, int coinType, int accountIndex)
+        public static ExtPubKey GetExtendedPublicKey(Key privateKey, byte[] chainCode, int purpose, int coinType, int accountIndex)
         {
             Guard.NotNull(privateKey, nameof(privateKey));
             Guard.NotNull(chainCode, nameof(chainCode));
 
-            string accountHdPath = GetAccountHdPath(coinType, accountIndex);
+            string accountHdPath = GetAccountHdPath(purpose, coinType, accountIndex);
             return GetExtendedPublicKey(privateKey, chainCode, accountHdPath);
         }
 
@@ -92,12 +93,13 @@ namespace Blockcore.Features.Wallet.Helpers
         /// <summary>
         /// Gets the HD path of an account.
         /// </summary>
+        /// <param name="purpose">Purpose of the coin this account is in.</param>
         /// <param name="coinType">Type of the coin this account is in.</param>
         /// <param name="accountIndex">Index of the account.</param>
         /// <returns>The HD path of an account.</returns>
-        public static string GetAccountHdPath(int coinType, int accountIndex)
+        public static string GetAccountHdPath(int purpose, int coinType, int accountIndex)
         {
-            return $"m/44'/{coinType}'/{accountIndex}'";
+            return $"m/{purpose}'/{coinType}'/{accountIndex}'";
         }
 
         /// <summary>
@@ -131,16 +133,17 @@ namespace Blockcore.Features.Wallet.Helpers
         /// <summary>
         /// Creates an address' HD path, according to BIP 44.
         /// </summary>
+        /// <param name="purpose">Purpose of the coin this account is in.</param>
         /// <param name="coinType">Type of coin in the HD path.</param>
         /// <param name="accountIndex">Index of the account in the HD path.</param>
         /// <param name="isChange">A value indicating whether the HD path to generate corresponds to a change address.</param>
         /// <param name="addressIndex">Index of the address in the HD path.</param>
         /// <returns>The HD path.</returns>
         /// <remarks>Refer to <seealso cref="https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels"/> for the format of the HD path.</remarks>
-        public static string CreateHdPath(int coinType, int accountIndex, bool isChange, int addressIndex)
+        public static string CreateHdPath(int purpose, int coinType, int accountIndex, bool isChange, int addressIndex)
         {
             int change = isChange ? 1 : 0;
-            return $"m/44'/{coinType}'/{accountIndex}'/{change}/{addressIndex}";
+            return $"m/{purpose}'/{coinType}'/{accountIndex}'/{change}/{addressIndex}";
         }
 
         /// <summary>

--- a/src/Features/Blockcore.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Features/Blockcore.Features.Wallet/Interfaces/IWalletManager.cs
@@ -82,8 +82,9 @@ namespace Blockcore.Features.Wallet.Interfaces
         /// <param name="passphrase">The passphrase used in the seed.</param>
         /// <param name="mnemonic">The user's mnemonic for the wallet.</param>
         /// <param name="coinType">Allow to override the default BIP44 cointype.</param>
+        /// <param name="purpose">An optional BIP44 purpose (also used in BIP84 and BIP49), this means specifying BIP84 to create a segwit wallet.</param>
         /// <returns>A mnemonic defining the wallet's seed used to generate addresses.</returns>
-        Mnemonic CreateWallet(string password, string name, string passphrase = null, Mnemonic mnemonic = null, int? coinType = null);
+        Mnemonic CreateWallet(string password, string name, string passphrase = null, Mnemonic mnemonic = null, int? coinType = null, int? purpose = null);
  
 
         /// <summary>
@@ -146,9 +147,10 @@ namespace Blockcore.Features.Wallet.Interfaces
         /// <param name="mnemonic">The user's mnemonic for the wallet.</param>
         /// <param name="passphrase">The passphrase used in the seed.</param>
         /// <param name="creationTime">The date and time this wallet was created.</param>
+        /// <param name="purpose">An optional BIP44 purpose (also used in BIP84 and BIP49), this means specifying BIP84 to create a segwit wallet.</param>
         /// <param name="coinType">Allow to override the default BIP44 cointype.</param>
         /// <returns>The recovered wallet.</returns>
-        Types.Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase = null, int? coinType = null, bool? isColdStakingWallet = false);
+        Types.Wallet RecoverWallet(string password, string name, string mnemonic, DateTime creationTime, string passphrase = null, int? purpose = null, int? coinType = null, bool? isColdStakingWallet = false);
 
         /// <summary>
         /// Recovers a wallet using extended public key and account index.
@@ -157,8 +159,9 @@ namespace Blockcore.Features.Wallet.Interfaces
         /// <param name="extPubKey">The extended public key.</param>
         /// <param name="accountIndex">The account number.</param>
         /// <param name="creationTime">The date and time this wallet was created.</param>
+        /// <param name="purpose">An optional BIP44 purpose (also used in BIP84 and BIP49), this means specifying BIP84 to create a segwit wallet.</param>
         /// <returns></returns>
-        Types.Wallet RecoverWallet(string name, ExtPubKey extPubKey, int accountIndex, DateTime creationTime);
+        Types.Wallet RecoverWallet(string name, ExtPubKey extPubKey, int accountIndex, DateTime creationTime, int? purpose = null);
 
         /// <summary>
         /// Deletes a wallet.
@@ -170,24 +173,26 @@ namespace Blockcore.Features.Wallet.Interfaces
         /// </summary>
         /// <param name="walletName">The name of the wallet from which to get an account.</param>
         /// <param name="password">The password used to decrypt the private key.</param>
+        /// <param name="purpose">An optional BIP44 purpose (also used in BIP84 and BIP49), this means specifying BIP84 to create a segwit wallet.</param>
         /// <remarks>
         /// According to BIP44, an account at index (i) can only be created when the account
         /// at index (i - 1) contains transactions.
         /// </remarks>
         /// <returns>An unused account.</returns>
-        HdAccount GetUnusedAccount(string walletName, string password);
+        HdAccount GetUnusedAccount(string walletName, string password, int? purpose = null);
 
         /// <summary>
         /// Gets an account that contains no transactions.
         /// </summary>
         /// <param name="wallet">The wallet from which to get an account.</param>
         /// <param name="password">The password used to decrypt the private key.</param>
+        /// <param name="purpose">An optional BIP44 purpose (also used in BIP84 and BIP49), this means specifying BIP84 to create a segwit wallet.</param>
         /// <remarks>
         /// According to BIP44, an account at index (i) can only be created when the account
         /// at index (i - 1) contains transactions.
         /// </remarks>
         /// <returns>An unused account.</returns>
-        HdAccount GetUnusedAccount(Types.Wallet wallet, string password);
+        HdAccount GetUnusedAccount(Types.Wallet wallet, string password, int? purpose = null);
 
         /// <summary>
         /// Gets an address that contains no transaction.

--- a/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
+++ b/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
@@ -44,6 +44,12 @@ namespace Blockcore.Features.Wallet.Types
         public IWalletStore walletStore { get; set; }
 
         /// <summary>
+        /// The wallet version.
+        /// </summary>
+        [JsonProperty(PropertyName = "version")]
+        public string Version { get; set; }
+
+        /// <summary>
         /// The name of this wallet.
         /// </summary>
         [JsonProperty(PropertyName = "name")]
@@ -798,8 +804,7 @@ namespace Blockcore.Features.Wallet.Types
                     newAddress.ScriptPubKey = pubkey.ScriptPubKey;
                     newAddress.Address = address.ToString();
                 }
-
-                if (newAddress.IsBip84())
+                else if (newAddress.IsBip84())
                 {
                     // Generate the PW2PKH address corresponding to the pubkey.
                     BitcoinWitPubKeyAddress witAddress = pubkey.GetSegwitAddress(network);

--- a/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
+++ b/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
@@ -968,12 +968,6 @@ namespace Blockcore.Features.Wallet.Types
         [JsonConverter(typeof(ScriptJsonConverter))]
         public Script Pubkey { get; set; }
 
-        ///// <summary>
-        ///// The base32 representation of a segwit (P2WPH) address.
-        ///// </summary>
-        //[JsonProperty(PropertyName = "bech32Address")]
-        //public string Bech32Address { get; set; }
-
         /// <summary>
         /// The Base58 representation of this address.
         /// </summary>

--- a/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
+++ b/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
@@ -47,7 +47,7 @@ namespace Blockcore.Features.Wallet.Types
         /// The wallet version.
         /// </summary>
         [JsonProperty(PropertyName = "version")]
-        public string Version { get; set; }
+        public int Version { get; set; }
 
         /// <summary>
         /// The name of this wallet.

--- a/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
+++ b/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
@@ -122,6 +122,16 @@ namespace Blockcore.Features.Wallet.Types
         }
 
         /// <summary>
+        /// Gets an account from the wallet's accounts.
+        /// </summary>
+        /// <param name="index">The index of the account to retrieve.</param>
+        /// <returns>The requested account or <c>null</c> if the account does not exist.</returns>
+        public HdAccount GetAccount(int index)
+        {
+            return this.AccountsRoot.SingleOrDefault()?.GetAccountByIndex(index);
+        }
+
+        /// <summary>
         /// Update the last block synced height and hash in the wallet.
         /// </summary>
         /// <param name="block">The block whose details are used to update the wallet.</param>
@@ -467,6 +477,16 @@ namespace Blockcore.Features.Wallet.Types
         public HdAccount GetAccountByName(string accountName)
         {
             return this.Accounts?.SingleOrDefault(a => a.Name == accountName);
+        }
+
+        /// <summary>
+        /// Gets the account matching the index passed as a parameter.
+        /// </summary>
+        /// <param name="index">The index of the account to get.</param>
+        /// <returns>The HD account specified by the parameter or <c>null</c> if the account does not exist.</returns>
+        public HdAccount GetAccountByIndex(int index)
+        {
+            return this.Accounts?.SingleOrDefault(a => a.Index == index);
         }
 
         /// <summary>

--- a/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
+++ b/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
@@ -814,7 +814,7 @@ namespace Blockcore.Features.Wallet.Types
                 {
                     // Generate the P2PKH address corresponding to the pubkey.
                     BitcoinPubKeyAddress address = pubkey.GetAddress(network);
-                    newAddress.ScriptPubKey = pubkey.ScriptPubKey;
+                    newAddress.ScriptPubKey = address.ScriptPubKey;
                     newAddress.Address = address.ToString();
                 }
                 else if (newAddress.IsBip84())

--- a/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
+++ b/src/Features/Blockcore.Features.Wallet/Types/Wallet.cs
@@ -915,11 +915,11 @@ namespace Blockcore.Features.Wallet.Types
         [JsonConverter(typeof(ScriptJsonConverter))]
         public Script Pubkey { get; set; }
 
-        /// <summary>
-        /// The base32 representation of a segwit (P2WPH) address.
-        /// </summary>
-        [JsonProperty(PropertyName = "bech32Address")]
-        public string Bech32Address { get; set; }
+        ///// <summary>
+        ///// The base32 representation of a segwit (P2WPH) address.
+        ///// </summary>
+        //[JsonProperty(PropertyName = "bech32Address")]
+        //public string Bech32Address { get; set; }
 
         /// <summary>
         /// The Base58 representation of this address.

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/Accounts.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/Accounts.razor
@@ -120,6 +120,7 @@
                                 <thead class="thead">
                                     <tr>
                                         <th class="text-primary"><strong>Account Name</strong></th>
+                                        <th class="text-primary"><strong>Format</strong></th>
                                         <th class="text-primary"><strong>CONFIRMED BALANCE</strong></th>
                                         <th class="text-primary"><strong>UNCONFIRMED BALANCE</strong></th>
                                         <th class="text-primary text-center"><strong>DETAILS</strong></th>
@@ -134,6 +135,7 @@
                                                 <td class="align-middle">
                                                     <button class="btn btn-sm btn-secondary" @onclick="() => { NavigateToWallet(walletname, _account.Name); }">@_account.Name</button>
                                                 </td>
+                                                <td class="align-middle">@ParseAccount(_account)</td>
                                                 <td class="align-middle">@accountBalance.AmountConfirmed</td>
                                                 <td class="align-middle">@accountBalance.AmountUnconfirmed</td>
                                                 <td class="text-center align-middle">
@@ -175,7 +177,20 @@
     {
         NavigationManager.NavigateTo("walletrecover");
     }
+    private string ParseAccount(Blockcore.Features.Wallet.Types.HdAccount account)
+    {
+        if (account.Purpose == 44)
+        {
+            return "legacy";
+        }
 
+        if (account.Purpose == 84)
+        {
+            return "segwit";
+        }
+
+        return "unknown";
+    }
     private Dictionary<string, (Types.AccountBalance AccountBalance, string AccountName)> ReadCurrentWallets()
     {
         var walletBalances = new Dictionary<string, (Types.AccountBalance AccountBalance, string AccountName)>();

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalViewSpendableTransactions.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalViewSpendableTransactions.razor
@@ -31,6 +31,12 @@
                             <CopyToClipboard Text="@_TModel.Address.ToString()" />
                         </div>
                     </div>
+                       <div class="form-group row">
+                        <label class="col-sm-2 col-form-label">ScriptPubKey</label>
+                          <label class="col-sm-10">
+                            @_TModel.Script
+                        </label>
+                    </div>
                     @*<div class="form-group row">
                         <label class="col-sm-2 col-form-label">Explorer</label>
                         <div class="col-sm-10">

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletCreate.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletCreate.razor
@@ -43,6 +43,23 @@
                             <input @bind="WalletName" type="text" class="form-control bg-secondary text-light" placeholder="Please enter your wallet name" />
                         </div>
                     </div>
+                     <div class="form-group row">
+                        <label class="col-sm-2 col-form-label">
+                            <span class="text">Format</span>
+                        </label>
+                        <div class="col-sm-10">
+                            <Dropdown TItem="(string name, int number)" OnSelected="@OnSelected">
+                                <InitialTip>Address Format</InitialTip>
+                                <ChildContent>
+                                    @foreach (var prp in Purposes)
+                                    {                                       
+                                         <DropdownListItem Item="@prp">@prp.name</DropdownListItem>
+                                    }
+                                </ChildContent>
+                            </Dropdown>
+
+                        </div>
+                    </div>
                     <div class="form-group row">
                         <label class="col-sm-2 col-form-label">
                             <span class="text">Password</span>
@@ -91,6 +108,8 @@ else
     public string Mnemonic { get; set; }
     private string Password { get; set; }
     private string Passphrase { get; set; }
+    private List<(string name, int number)> Purposes { get; set; } = new List<(string name, int number)> { ("Legacy", 44), ("Segwit", 84) };
+    private int Purpose { get; set; }
     string Alert { get; set; }
     private bool IsSubmitting { get; set; }
     private async Task callCreateWallet()
@@ -108,11 +127,12 @@ else
         if (string.IsNullOrEmpty(this.Mnemonic)) { this.Alert = "Ensure that you have generated a new Mnemonic"; return; }
         if (string.IsNullOrEmpty(this.WalletName)) { this.Alert = "Please enter a wallet name"; return; }
         if (string.IsNullOrEmpty(this.Password)) { this.Alert = "Please enter a password"; return; }
+        if (this.Purpose != 44 && this.Purpose != 84) { this.Alert = "Select address format"; return; }
         if (this.Passphrase == null)
             this.Passphrase = string.Empty;
         this.Alert = string.Empty;
         var requestMnemonic = new Mnemonic(this.Mnemonic);
-        Mnemonic mnemonic = this.WalletManager.CreateWallet(this.Password, this.WalletName, this.Passphrase, mnemonic: requestMnemonic);
+        Mnemonic mnemonic = this.WalletManager.CreateWallet(this.Password, this.WalletName, this.Passphrase, purpose: this.Purpose, mnemonic: requestMnemonic);
         // start syncing the wallet from the creation date
         this.WalletSyncManager.SyncFromDate(this.DateTimeProvider.GetUtcNow());
         this.Alert = "Your wallet has now been created.";
@@ -128,5 +148,9 @@ else
     {
         ModalService.Close();
         NavigationManager.NavigateTo("walletview/" + WalletName + "/account 0");
+    }
+    private void OnSelected((string name, int number) selection)
+    {
+        this.Purpose = selection.number;
     }
 }

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletCreate.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletCreate.razor
@@ -48,16 +48,15 @@
                             <span class="text">Format</span>
                         </label>
                         <div class="col-sm-10">
-                            <Dropdown TItem="(string name, int number)" OnSelected="@OnSelected">
-                                <InitialTip>Address Format</InitialTip>
-                                <ChildContent>
+                            <select @bind="SelectedPurpose" type="text" class="form-control bg-secondary text-light">
+                                <option value=""></option>
+                                @{
                                     @foreach (var prp in Purposes)
-                                    {                                       
-                                         <DropdownListItem Item="@prp">@prp.name</DropdownListItem>
+                                    {          
+                                        <option value="@prp">@prp</option>
                                     }
-                                </ChildContent>
-                            </Dropdown>
-
+                                }
+                            </select>
                         </div>
                     </div>
                     <div class="form-group row">
@@ -108,7 +107,8 @@ else
     public string Mnemonic { get; set; }
     private string Password { get; set; }
     private string Passphrase { get; set; }
-    private List<(string name, int number)> Purposes { get; set; } = new List<(string name, int number)> { ("Legacy", 44), ("Segwit", 84) };
+    private List<string> Purposes { get; set; } = new List<string> { "Legacy", "Segwit" };
+    private string SelectedPurpose { get; set; }
     private int Purpose { get; set; }
     string Alert { get; set; }
     private bool IsSubmitting { get; set; }
@@ -124,6 +124,9 @@ else
     }
     private async Task CreateWallet()
     {
+        if (SelectedPurpose == "Legacy") Purpose = 44;
+        if (SelectedPurpose == "Segwit") Purpose = 84;
+
         if (string.IsNullOrEmpty(this.Mnemonic)) { this.Alert = "Ensure that you have generated a new Mnemonic"; return; }
         if (string.IsNullOrEmpty(this.WalletName)) { this.Alert = "Please enter a wallet name"; return; }
         if (string.IsNullOrEmpty(this.Password)) { this.Alert = "Please enter a password"; return; }
@@ -148,9 +151,5 @@ else
     {
         ModalService.Close();
         NavigationManager.NavigateTo("walletview/" + WalletName + "/account 0");
-    }
-    private void OnSelected((string name, int number) selection)
-    {
-        this.Purpose = selection.number;
     }
 }

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletRecover.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletRecover.razor
@@ -46,16 +46,15 @@
                             <span class="text">Format</span>
                         </label>
                         <div class="col-sm-10">
-                            <Dropdown TItem="(string name, int number)" OnSelected="@OnSelected">
-                                <InitialTip>Address Format</InitialTip>
-                                <ChildContent>
+                            <select @bind="SelectedPurpose" type="text" class="form-control bg-secondary text-light">
+                                <option value=""></option>
+                                @{
                                     @foreach (var prp in Purposes)
-                                    {                                       
-                                         <DropdownListItem Item="@prp">@prp.name</DropdownListItem>
+                                    {          
+                                        <option value="@prp">@prp</option>
                                     }
-                                </ChildContent>
-                            </Dropdown>
-
+                                }
+                            </select>
                         </div>
                     </div>
 
@@ -115,7 +114,8 @@ else
     public string Mnemonic { get; set; }
     private string Password { get; set; }
     private string Passphrase { get; set; }
-    private List<(string name, int number)> Purposes { get; set; } = new List<(string name, int number)> { ("Legacy", 44), ("Segwit", 84) };
+    private List<string> Purposes { get; set; } = new List<string> { "Legacy", "Segwit" };
+    private string SelectedPurpose { get; set; }
     private int Purpose { get; set; }
     string Alert { get; set; }
     private bool IsSubmitting { get; set; }
@@ -131,6 +131,9 @@ else
     }
     private async Task RecoverWallet()
     {
+        if (SelectedPurpose == "Legacy") Purpose = 44;
+        if (SelectedPurpose == "Segwit") Purpose = 84;
+
         if (string.IsNullOrEmpty(this.Mnemonic)) { this.Alert = "Ensure that you have entered your Mnemonic"; return; }
         if (string.IsNullOrEmpty(this.WalletName)) { this.Alert = "Please enter a wallet name"; return; }
         if (string.IsNullOrEmpty(this.Password)) { this.Alert = "Please enter a password"; return; }
@@ -142,9 +145,5 @@ else
         this.Alert = "Your wallet has now been recovered.";
         ShowForm = false;
         await Task.CompletedTask;
-    }
-    private void OnSelected((string name, int number) selection)
-    {
-        this.Purpose = selection.number;
     }
 }

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletRecover.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/Modal/ModalWalletRecover.razor
@@ -40,6 +40,24 @@
                             <input @bind="WalletName" type="text" class="form-control bg-secondary text-light" placeholder="Please enter your wallet name" />
                         </div>
                     </div>
+                    
+                    <div class="form-group row">
+                        <label class="col-sm-2 col-form-label">
+                            <span class="text">Format</span>
+                        </label>
+                        <div class="col-sm-10">
+                            <Dropdown TItem="(string name, int number)" OnSelected="@OnSelected">
+                                <InitialTip>Address Format</InitialTip>
+                                <ChildContent>
+                                    @foreach (var prp in Purposes)
+                                    {                                       
+                                         <DropdownListItem Item="@prp">@prp.name</DropdownListItem>
+                                    }
+                                </ChildContent>
+                            </Dropdown>
+
+                        </div>
+                    </div>
 
                     <div class="form-group row">
                         <label class="col-sm-2 col-form-label">
@@ -97,6 +115,8 @@ else
     public string Mnemonic { get; set; }
     private string Password { get; set; }
     private string Passphrase { get; set; }
+    private List<(string name, int number)> Purposes { get; set; } = new List<(string name, int number)> { ("Legacy", 44), ("Segwit", 84) };
+    private int Purpose { get; set; }
     string Alert { get; set; }
     private bool IsSubmitting { get; set; }
     private async Task callRecoverWallet()
@@ -114,12 +134,17 @@ else
         if (string.IsNullOrEmpty(this.Mnemonic)) { this.Alert = "Ensure that you have entered your Mnemonic"; return; }
         if (string.IsNullOrEmpty(this.WalletName)) { this.Alert = "Please enter a wallet name"; return; }
         if (string.IsNullOrEmpty(this.Password)) { this.Alert = "Please enter a password"; return; }
+        if (this.Purpose != 44 && this.Purpose != 84) { this.Alert = "Select address format"; return; }
         if (this.Passphrase == null)
             this.Passphrase = string.Empty;
         this.Alert = string.Empty;
-        var wallet = this.WalletManager.RecoverWallet(this.Password, this.WalletName, this.Mnemonic, this.DateTimeProvider.GetUtcNow(), passphrase: this.Passphrase);
+        var wallet = this.WalletManager.RecoverWallet(this.Password, this.WalletName, this.Mnemonic, this.DateTimeProvider.GetUtcNow(), passphrase: this.Passphrase, purpose: this.Purpose);
         this.Alert = "Your wallet has now been recovered.";
         ShowForm = false;
         await Task.CompletedTask;
+    }
+    private void OnSelected((string name, int number) selection)
+    {
+        this.Purpose = selection.number;
     }
 }

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/UTXOList.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/UTXOList.razor
@@ -134,6 +134,7 @@
                     Id = st.Transaction.Id,
                     Amount = st.Transaction.Amount,
                     Address = st.Address.Address,
+                    Script = st.Transaction.ScriptPubKey.ToString(),
                     Index = st.Transaction.Index,
                     IsChange = st.Address.IsChangeAddress(),
                     CreationTime = st.Transaction.CreationTime,

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/WalletReceive.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/WalletReceive.razor
@@ -35,16 +35,8 @@
         </div>
         <div class="card-body">
             <div class="row">
-                @if (NodeDeployments.GetFlags().ScriptFlags.HasFlag(ScriptVerify.Witness))
-                {
-                    <div class="col-sm-2"><strong>Address:</strong></div>
-                    <div class="col-sm-10"><CopyToClipboard Text="@result.Bech32Address" /></div>
-                }
-                else
-                {
-                    <div class="col-sm-2"><strong>Address:</strong></div>
-                    <div class="col-sm-10"><CopyToClipboard Text="@result.Address" /></div>
-                }
+                <div class="col-sm-2"><strong>Address:</strong></div>
+                <div class="col-sm-10"><CopyToClipboard Text="@result.Address" /></div>
             </div>
         </div>
     </div>
@@ -60,9 +52,7 @@
 
                     return new AddressModel
                     {
-                        Address = (bool)(NodeDeployments.GetFlags().ScriptFlags.HasFlag(ScriptVerify.Witness)) ? address.Bech32Address : address.Address,
-                        // Address =  request.Segwit ? address.Bech32Address : address.Address,
-                        //  Address = address.Address,
+                        Address = address.Address,
                         IsUsed = anyTrx,
                         IsChange = address.IsChangeAddress(),
                         AmountConfirmed = confirmedAmount,

--- a/src/Features/Blockcore.Features.Wallet/UI/Pages/WalletSend.razor
+++ b/src/Features/Blockcore.Features.Wallet/UI/Pages/WalletSend.razor
@@ -337,7 +337,6 @@
                     Shuffle = true, // We shuffle transaction outputs by default as it's better for anonymity.
                     WalletPassword = Password,
                     Recipients = recipients,
-                    UseSegwitChangeAddress = recipients[0].ScriptPubKey.IsScriptType(ScriptType.Witness),
                     TransactionFee = new Money(this.Fee, MoneyUnit.BTC)
                 };
 

--- a/src/Features/Blockcore.Features.Wallet/WalletManager.cs
+++ b/src/Features/Blockcore.Features.Wallet/WalletManager.cs
@@ -1767,7 +1767,7 @@ namespace Blockcore.Features.Wallet
             {
                 walletIndex.ScriptToAddressLookup[address.ScriptPubKey] = address;
 
-                if (wallet.Version < 2)
+                if (wallet.Version < 2 && address.Pubkey != null)
                 {
                     var pubkey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(address.Pubkey);
                     BitcoinWitPubKeyAddress witAddress = pubkey.GetSegwitAddress(this.network);

--- a/src/Features/Blockcore.Features.Wallet/WalletManager.cs
+++ b/src/Features/Blockcore.Features.Wallet/WalletManager.cs
@@ -887,7 +887,7 @@ namespace Blockcore.Features.Wallet
 
                 foreach (Types.Wallet wallet in this.Wallets)
                 {
-                    hdAddress = wallet.GetAllAddresses().FirstOrDefault(a => a.Address == address || a.Bech32Address == address);
+                    hdAddress = wallet.GetAllAddresses().FirstOrDefault(a => a.Address == address);
                     if (hdAddress == null) continue;
 
                     // When this query to get balance on specific address, we will exclude the cold staking UTXOs.
@@ -1743,15 +1743,16 @@ namespace Blockcore.Features.Wallet
             }
 
             // Track the P2PKH of this pubic key
-            walletIndex.ScriptToAddressLookup[address.ScriptPubKey] = address;
+            if (address.IsBip44())
+                walletIndex.ScriptToAddressLookup[address.ScriptPubKey] = address;
 
             // Track the P2PK of this public key
             if (address.Pubkey != null)
                 walletIndex.ScriptToAddressLookup[address.Pubkey] = address;
 
             // Track the P2WPKH of this pubic key
-            if (address.Bech32Address != null)
-                walletIndex.ScriptToAddressLookup[new BitcoinWitPubKeyAddress(address.Bech32Address, this.network).ScriptPubKey] = address;
+            if (address.IsBip84())
+                walletIndex.ScriptToAddressLookup[new BitcoinWitPubKeyAddress(address.Address, this.network).ScriptPubKey] = address;
         }
 
         /// <summary>

--- a/src/Features/Blockcore.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Features/Blockcore.Features.Wallet/WalletTransactionHandler.cs
@@ -281,9 +281,10 @@ namespace Blockcore.Features.Wallet
                 context.ChangeAddress = this.walletManager.GetUnusedChangeAddress(new WalletAccountReference(context.AccountReference.WalletName, context.AccountReference.AccountName));
             }
 
-            if (context.UseSegwitChangeAddress)
+            if (context.ChangeAddress.IsBip84())
             {
-                context.TransactionBuilder.SetChange(new BitcoinWitPubKeyAddress(context.ChangeAddress.Bech32Address, this.network).ScriptPubKey);
+                // TODO: do we actually need this conversion? the context.ChangeAddress.ScriptPubKey should already be a setwit script 
+                context.TransactionBuilder.SetChange(new BitcoinWitPubKeyAddress(context.ChangeAddress.Address, this.network).ScriptPubKey);
             }
             else
             {
@@ -570,10 +571,5 @@ namespace Blockcore.Features.Wallet
         /// The timestamp to set on the transaction.
         /// </summary>
         public uint? Time { get; set; }
-
-        /// <summary>
-        /// Whether to send the change to a P2WPKH (segwit bech32) addresses, or a regular P2PKH address
-        /// </summary>
-        public bool UseSegwitChangeAddress { get; set; }
     }
 }

--- a/src/Features/Blockcore.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Features/Blockcore.Features.Wallet/WalletTransactionHandler.cs
@@ -281,15 +281,7 @@ namespace Blockcore.Features.Wallet
                 context.ChangeAddress = this.walletManager.GetUnusedChangeAddress(new WalletAccountReference(context.AccountReference.WalletName, context.AccountReference.AccountName));
             }
 
-            if (context.ChangeAddress.IsBip84())
-            {
-                // TODO: do we actually need this conversion? the context.ChangeAddress.ScriptPubKey should already be a setwit script 
-                context.TransactionBuilder.SetChange(new BitcoinWitPubKeyAddress(context.ChangeAddress.Address, this.network).ScriptPubKey);
-            }
-            else
-            {
-                context.TransactionBuilder.SetChange(context.ChangeAddress.ScriptPubKey);
-            }
+            context.TransactionBuilder.SetChange(context.ChangeAddress.ScriptPubKey);
         }
 
         /// <summary>

--- a/src/Tests/Blockcore.Features.ColdStaking.Tests/ColdStakingManagerTest.cs
+++ b/src/Tests/Blockcore.Features.ColdStaking.Tests/ColdStakingManagerTest.cs
@@ -162,6 +162,7 @@ namespace Blockcore.Features.ColdStaking.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account 0",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -172,6 +173,7 @@ namespace Blockcore.Features.ColdStaking.Tests
             coldWallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = ColdStakingManager.ColdWalletAccountIndex,
+                Purpose = 44,
                 Name = ColdStakingManager.ColdWalletAccountName,
                 HdPath = $"m/44'/0'/{ColdStakingManager.ColdWalletAccountIndex}'",
                 ExtendedPubKey = accountColdKeys.ExtPubKey,
@@ -182,6 +184,7 @@ namespace Blockcore.Features.ColdStaking.Tests
             hotWallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = ColdStakingManager.HotWalletAccountIndex,
+                Purpose = 44,
                 Name = ColdStakingManager.HotWalletAccountName,
                 HdPath = $"m/44'/0'/{ColdStakingManager.HotWalletAccountIndex}'",
                 ExtendedPubKey = accountHotKeys.ExtPubKey,

--- a/src/Tests/Blockcore.Features.Wallet.Tests/WalletControllerTest.cs
+++ b/src/Tests/Blockcore.Features.Wallet.Tests/WalletControllerTest.cs
@@ -226,7 +226,7 @@ namespace Blockcore.Features.Wallet.Tests
         {
             var mnemonic = new Mnemonic(Wordlist.English, WordCount.Twelve);
             var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null)).Returns(mnemonic);
+            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null, null)).Returns(mnemonic);
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
 
@@ -272,7 +272,7 @@ namespace Blockcore.Features.Wallet.Tests
         {
             string errorMessage = "An error occurred.";
             var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null))
+            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null, null))
                 .Throws(new WalletException(errorMessage));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -298,7 +298,7 @@ namespace Blockcore.Features.Wallet.Tests
         public void CreateWalletWithNotSupportedExceptionExceptionReturnsBadRequest()
         {
             var mockWalletCreate = new Mock<IWalletManager>();
-            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null))
+            mockWalletCreate.Setup(wallet => wallet.CreateWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Mnemonic>(), null, null))
                 .Throws(new NotSupportedException("Not supported"));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletCreate.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -330,7 +330,7 @@ namespace Blockcore.Features.Wallet.Tests
             };
 
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null)).Returns(wallet);
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null, null)).Returns(wallet);
 
             Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
             walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
@@ -368,7 +368,7 @@ namespace Blockcore.Features.Wallet.Tests
             DateTime lastBlockDateTime = chainIndexer.Tip.Header.BlockTime.DateTime;
 
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null)).Returns(wallet);
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null, null)).Returns(wallet);
 
             Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
             walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
@@ -419,7 +419,7 @@ namespace Blockcore.Features.Wallet.Tests
         {
             string errorMessage = "An error occurred.";
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null))
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null, null))
                 .Throws(new WalletException(errorMessage));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -445,7 +445,7 @@ namespace Blockcore.Features.Wallet.Tests
         public void RecoverWalletWithFileNotFoundExceptionReturnsNotFound()
         {
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null))
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null, null))
                 .Throws(new FileNotFoundException("File not found."));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -472,7 +472,7 @@ namespace Blockcore.Features.Wallet.Tests
         public void RecoverWalletWithExceptionReturnsBadRequest()
         {
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null))
+            mockWalletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), null, null, null, null))
                 .Throws(new FormatException("Formatting failed."));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -523,7 +523,7 @@ namespace Blockcore.Features.Wallet.Tests
             };
 
             var walletManager = new Mock<IWalletManager>();
-            walletManager.Setup(w => w.RecoverWallet(walletName, It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>())).Returns(wallet);
+            walletManager.Setup(w => w.RecoverWallet(walletName, It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>(), null)).Returns(wallet);
 
             Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
             walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
@@ -569,7 +569,7 @@ namespace Blockcore.Features.Wallet.Tests
             DateTime lastBlockDateTime = chainIndexer.Tip.Header.BlockTime.DateTime;
 
             var walletManager = new Mock<IWalletManager>();
-            walletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>())).Returns(wallet);
+            walletManager.Setup(w => w.RecoverWallet(It.IsAny<string>(), It.IsAny<ExtPubKey>(), 1, It.IsAny<DateTime>(), null)).Returns(wallet);
 
             Mock<IWalletSyncManager> walletSyncManager = new Mock<IWalletSyncManager>();
             walletSyncManager.Setup(w => w.WalletTip).Returns(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().Header.GetHash(), 3));
@@ -1922,7 +1922,7 @@ namespace Blockcore.Features.Wallet.Tests
         public void CreateNewAccountWithValidModelReturnsAccountName()
         {
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(m => m.GetUnusedAccount("myWallet", "test"))
+            mockWalletManager.Setup(m => m.GetUnusedAccount("myWallet", "test", null))
                 .Returns(new HdAccount { Name = "Account 1" });
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);
@@ -1963,7 +1963,7 @@ namespace Blockcore.Features.Wallet.Tests
         public void CreateNewAccountWithExceptionReturnsBadRequest()
         {
             var mockWalletManager = new Mock<IWalletManager>();
-            mockWalletManager.Setup(m => m.GetUnusedAccount("myWallet", "test"))
+            mockWalletManager.Setup(m => m.GetUnusedAccount("myWallet", "test", null))
                 .Throws(new InvalidOperationException("Wallet not found."));
 
             var controller = new WalletController(this.LoggerFactory.Object, mockWalletManager.Object, new Mock<IWalletTransactionHandler>().Object, new Mock<IWalletSyncManager>().Object, It.IsAny<ConnectionManager>(), this.Network, this.chainIndexer, new Mock<IBroadcasterManager>().Object, DateTimeProvider.Default);

--- a/src/Tests/Blockcore.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Tests/Blockcore.Features.Wallet.Tests/WalletManagerTest.cs
@@ -654,7 +654,7 @@ namespace Blockcore.Features.Wallet.Tests
 
             Assert.Equal(1, wallet.AccountsRoot.ElementAt(0).Accounts.Count);
             var extKey = new ExtKey(Key.Parse(wallet.EncryptedSeed, "password", wallet.Network), wallet.ChainCode);
-            string expectedExtendedPubKey = extKey.Derive(new KeyPath($"m/44'/0'/0'")).Neuter().ToString(wallet.Network);
+            string expectedExtendedPubKey = extKey.Derive(new KeyPath($"m/84'/0'/0'")).Neuter().ToString(wallet.Network);
             Assert.Equal($"account 0", result.Name);
             Assert.Equal(0, result.Index);
             Assert.Equal($"m/84'/0'/0'", result.HdPath);
@@ -807,6 +807,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "myAccount",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountExtendedPubKey,
@@ -833,6 +834,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "myAccount",
                 HdPath = "m/44'/0'/0'",
                 ExternalAddresses = new List<HdAddress>
@@ -878,6 +880,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "myAccount",
                 HdPath = "m/44'/0'/0'",
                 ExternalAddresses = new List<HdAddress>
@@ -921,6 +924,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "myAccount",
                 HdPath = "m/44'/0'/0'",
                 ExternalAddresses = new List<HdAddress>
@@ -963,6 +967,7 @@ namespace Blockcore.Features.Wallet.Tests
             var account = new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "myAccount",
                 HdPath = "m/44'/0'/0'",
                 ExternalAddresses = new List<HdAddress>
@@ -1008,6 +1013,7 @@ namespace Blockcore.Features.Wallet.Tests
             var account = new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "myAccount",
                 HdPath = "m/44'/0'/0'",
                 ExternalAddresses = new List<HdAddress>(),
@@ -1351,6 +1357,7 @@ namespace Blockcore.Features.Wallet.Tests
             data.wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 ExternalAddresses = new List<HdAddress> {
                     address
                 },
@@ -1382,6 +1389,7 @@ namespace Blockcore.Features.Wallet.Tests
                 data.wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
                 {
                     Index = 0,
+                    Purpose = 44,
                     ExternalAddresses = new List<HdAddress>(),
                     InternalAddresses = new List<HdAddress>(),
                     Name = "savings account"
@@ -1443,6 +1451,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -1533,6 +1542,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -1620,6 +1630,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -1702,6 +1713,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -1787,6 +1799,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -1884,6 +1897,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -2276,6 +2290,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Name = "First account",
+                Purpose = 44,
                 ExternalAddresses = WalletTestsHelpers.CreateSpentTransactionsOfBlockHeights((WalletMemoryStore)wallet.walletStore, this.Network, 1, 2, 3, 4, 5).ToList(),
                 InternalAddresses = WalletTestsHelpers.CreateSpentTransactionsOfBlockHeights((WalletMemoryStore)wallet.walletStore, this.Network, 1, 2, 3, 4, 5).ToList()
             });
@@ -2384,6 +2399,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -3132,6 +3148,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,

--- a/src/Tests/Blockcore.Features.Wallet.Tests/WalletManagerTest.cs
+++ b/src/Tests/Blockcore.Features.Wallet.Tests/WalletManagerTest.cs
@@ -2823,7 +2823,7 @@ namespace Blockcore.Features.Wallet.Tests
         [Fact]
         public void CreateBip44PathWithChangeAddressReturnsPath()
         {
-            string result = HdOperations.CreateHdPath((int)KnownCoinTypes.Stratis, 4, true, 3);
+            string result = HdOperations.CreateHdPath(44, (int)KnownCoinTypes.Stratis, 4, true, 3);
 
             Assert.Equal("m/44'/105'/4'/1/3", result);
         }
@@ -2831,9 +2831,17 @@ namespace Blockcore.Features.Wallet.Tests
         [Fact]
         public void CreateBip44PathWithoutChangeAddressReturnsPath()
         {
-            string result = HdOperations.CreateHdPath((int)KnownCoinTypes.Stratis, 4, false, 3);
+            string result = HdOperations.CreateHdPath(44, (int)KnownCoinTypes.Stratis, 4, false, 3);
 
             Assert.Equal("m/44'/105'/4'/0/3", result);
+        }
+
+        [Fact]
+        public void CreateBip84PathWithoutChangeAddressReturnsPath()
+        {
+            string result = HdOperations.CreateHdPath(84, (int)KnownCoinTypes.Stratis, 4, false, 3);
+
+            Assert.Equal("m/84'/105'/4'/0/3", result);
         }
 
         [Fact]

--- a/src/Tests/Blockcore.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
+++ b/src/Tests/Blockcore.Features.Wallet.Tests/WalletTransactionHandlerTest.cs
@@ -340,6 +340,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,
@@ -701,6 +702,7 @@ namespace Blockcore.Features.Wallet.Tests
             wallet.AccountsRoot.ElementAt(0).Accounts.Add(new HdAccount
             {
                 Index = 0,
+                Purpose = 44,
                 Name = "account1",
                 HdPath = "m/44'/0'/0'",
                 ExtendedPubKey = accountKeys.ExtPubKey,

--- a/src/Tests/Blockcore.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
+++ b/src/Tests/Blockcore.IntegrationTests.Common/EnvironmentMockUpHelpers/CoreNode.cs
@@ -77,6 +77,7 @@ namespace Blockcore.IntegrationTests.Common.EnvironmentMockUpHelpers
         private bool builderOverrideDateTimeProvider;
         private bool builderWithDummyWallet;
         private bool builderWithWallet;
+        private bool builderWithSegwitWallet;
         private string builderWalletName;
         private string builderWalletPassword;
         private string builderWalletPassphrase;
@@ -221,6 +222,27 @@ namespace Blockcore.IntegrationTests.Common.EnvironmentMockUpHelpers
             this.builderWalletPassphrase = walletPassphrase;
             this.builderWalletPassword = walletPassword;
             this.builderWalletMnemonic = walletMnemonic;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a segwit wallet to this node with defaulted parameters under the BIP84 derivation path.
+        /// </summary>
+        /// <param name="walletPassword">Wallet password defaulted to "password".</param>
+        /// <param name="walletName">Wallet name defaulted to "mywallet".</param>
+        /// <param name="walletPassphrase">Wallet passphrase defaulted to "passphrase".</param>
+        /// <param name="walletMnemonic">Optional wallet mnemonic.</param>
+        /// <returns>This node.</returns>
+        public CoreNode WithSegwitWallet(string walletPassword = "password", string walletName = "mywallet", string walletPassphrase = "passphrase", string walletMnemonic = null)
+        {
+            this.builderWithDummyWallet = false;
+            this.builderWithWallet = true;
+            this.builderWithSegwitWallet = true;
+            this.builderWalletName = walletName;
+            this.builderWalletPassphrase = walletPassphrase;
+            this.builderWalletPassword = walletPassword;
+            this.builderWalletMnemonic = walletMnemonic;
+
             return this;
         }
 
@@ -445,7 +467,7 @@ namespace Blockcore.IntegrationTests.Common.EnvironmentMockUpHelpers
                     this.builderWalletPassword,
                     this.builderWalletName,
                     this.builderWalletPassphrase,
-                    string.IsNullOrEmpty(this.builderWalletMnemonic) ? null : new Mnemonic(this.builderWalletMnemonic));
+                    string.IsNullOrEmpty(this.builderWalletMnemonic) ? null : new Mnemonic(this.builderWalletMnemonic), purpose: this.builderWithSegwitWallet ? 84 : null);
             }
         }
 

--- a/src/Tests/Blockcore.IntegrationTests/API/ApiSteps.cs
+++ b/src/Tests/Blockcore.IntegrationTests/API/ApiSteps.cs
@@ -458,7 +458,7 @@ namespace Blockcore.IntegrationTests.API
             commands.Should().Contain(x => x.Command == "walletpassphrase <passphrase> <timeout>");
             commands.Should().Contain(x => x.Command == "walletlock");
             commands.Should().Contain(x => x.Command == "getwalletinfo");
-            commands.Should().Contain(x => x.Command == "sendtoaddress <address> <amount> <commenttx> <commentdest> [<fee>] [<issegwit>]");
+            commands.Should().Contain(x => x.Command == "sendtoaddress <address> <amount> <commenttx> <commentdest> [<fee>]");
             commands.Should().Contain(x => x.Command == "sendrawtransaction <hex>");
             commands.Should().Contain(x => x.Command == "getnewaddress [<account>] [<addresstype>]");
             commands.Should().Contain(x => x.Command == "getunusedaddress <account> <addresstype>");

--- a/src/Tests/Blockcore.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Tests/Blockcore.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -134,7 +134,7 @@ namespace Blockcore.IntegrationTests.RPC
                 var alice = new Key().GetBitcoinSecret(network);
                 var aliceAddress = alice.GetAddress();
                 rpcClient.WalletPassphrase("password", 60);
-                var txid = rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
+                var txid = rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m);
                 rpcClient.SendCommand(RPCOperations.walletlock);
 
                 // Check the hash calculated correctly.
@@ -159,19 +159,19 @@ namespace Blockcore.IntegrationTests.RPC
                 RPCClient rpcClient = node.CreateRPCClient();
 
                 // Not unlocked case.
-                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
+                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
 
                 // Unlock and lock case.
                 rpcClient.WalletPassphrase("password", 60);
                 rpcClient.SendCommand(RPCOperations.walletlock);
-                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
+                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
 
                 // Unlock timesout case.
                 rpcClient.WalletPassphrase("password", 5);
                 Thread.Sleep(10 * 1000); // 10 seconds.
-                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
+                action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
             }
         }
@@ -294,17 +294,17 @@ namespace Blockcore.IntegrationTests.RPC
                 rpcClient.WalletPassphrase("password", 20);
 
                 // Send a transaction.
-                rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false).Should().NotBeNull();
+                rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m).Should().NotBeNull();
 
                 // Wait 10 seconds and then send another transaction, should still be unlocked.
                 Thread.Sleep(10 * 1000);
 
                 var bobAddress = new Key().GetBitcoinSecret(network).GetAddress();
-                rpcClient.SendToAddress(bobAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false).Should().NotBeNull();
+                rpcClient.SendToAddress(bobAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m).Should().NotBeNull();
 
                 // Now wait 10 seconds so the wallet should be back locked and a transaction should fail.
                 Thread.Sleep(10 * 1000);
-                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m, false);
+                Action action = () => rpcClient.SendToAddress(aliceAddress, Money.Coins(1.0m), "CommentTX", "CommentDest", 0.01m);
                 action.Should().Throw<RPCException>().Which.RPCCode.Should().Be(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED);
             }
         }

--- a/src/Tests/Blockcore.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
+++ b/src/Tests/Blockcore.IntegrationTests/Wallet/WalletAddressGenerationAndFundsVisibility_Steps.cs
@@ -109,7 +109,7 @@ namespace Blockcore.IntegrationTests.Wallet
         {
             ExtKey xPrivKey = node.Mnemonic.DeriveExtKey(WalletPassphrase);
             Key privateKey = xPrivKey.PrivateKey;
-            ExtPubKey xPublicKey = HdOperations.GetExtendedPublicKey(privateKey, xPrivKey.ChainCode, KnownCoinTypes.Bitcoin, 0);
+            ExtPubKey xPublicKey = HdOperations.GetExtendedPublicKey(privateKey, xPrivKey.ChainCode, 44, KnownCoinTypes.Bitcoin, 0);
             return xPublicKey;
         }
 

--- a/src/Tests/Blockcore.Tests.Wallet.Common/WalletTestsHelpers.cs
+++ b/src/Tests/Blockcore.Tests.Wallet.Common/WalletTestsHelpers.cs
@@ -245,11 +245,13 @@ namespace Blockcore.Tests.Wallet.Common
                     {
                         new HdAccount
                         {
+                            Purpose = 44,
                             ExternalAddresses = GenerateAddresses(count),
                             InternalAddresses = GenerateAddresses(count)
                         },
                         new HdAccount
                         {
+                            Purpose = 44,
                             ExternalAddresses = GenerateAddresses(count),
                             InternalAddresses = GenerateAddresses(count)
                         } }
@@ -262,8 +264,9 @@ namespace Blockcore.Tests.Wallet.Common
             return new HdAddress
             {
                 Index = index,
+                HdPath = "m/44'/0'/0'/0/0",
                 Address = addressName,
-                ScriptPubKey = new Script(),
+                ScriptPubKey = new Script()
                 //Transactions = new List<TransactionData>()
             };
         }
@@ -273,8 +276,9 @@ namespace Blockcore.Tests.Wallet.Common
             return new HdAddress
             {
                 Index = index,
+                HdPath = "m/44'/0'/0'/0/0",
                 Address = addressName,
-                ScriptPubKey = new Script(),
+                ScriptPubKey = new Script()
                 //Transactions = new List<TransactionData> { new TransactionData() }
             };
         }
@@ -289,7 +293,8 @@ namespace Blockcore.Tests.Wallet.Common
                 var address = new HdAddress
                 {
                     Address = key.ToString(),
-                    ScriptPubKey = key
+                    ScriptPubKey = key,
+                    HdPath = $"m/44'/0'/0'/0/{count}",
                 };
                 addresses.Add(address);
             }
@@ -440,6 +445,7 @@ namespace Blockcore.Tests.Wallet.Common
                 {
                     Address = key.PubKey.GetAddress(network).ToString(),
                     ScriptPubKey = key.ScriptPubKey,
+                    HdPath = "m/44'/0'/0'/0/0",
                 };
 
                 store.Add(new List<TransactionOutputData> {


### PR DESCRIPTION
This is likely going to be a big PR
And it is probably going to be a breaking change PR to the wallet, meaning old wallets that used segwit will break if recovered after this PR is pushed 

The intention is to delete the flag `Bech32Address` and instead recover wallets under the correct segwit path.

Relevant BIPs
https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki