### PR TITLE
Dotnet8 Upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          6.0.x
+          8.0.x
 
     - name: Setup Node.js (16.x)
       uses: actions/setup-node@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dotnet8
 #  repository_dispatch:
 #    types: [build]
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - dotnet8
 #  repository_dispatch:
 #    types: [build]
   workflow_dispatch:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          6.0.x
+          8.0.x
 
     - name: Restore
       run: dotnet restore ${{env.SOLUTION_PATH}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          6.0.x
+          8.0.x
 
     - name: Log Variables
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          6.0.x
+          8.0.x
 
     - name: Restore
       run: dotnet restore ${{env.SOLUTION_PATH}}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Version>1.1.41</Version>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>Blockcore</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Tests/Blockcore.Tests/P2P/NetworkPeerServerTests.cs
+++ b/src/Tests/Blockcore.Tests/P2P/NetworkPeerServerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -72,10 +73,15 @@ namespace Blockcore.Tests.P2P
             const int portNumber = 80;
             var client = new TcpClient("www.stratisplatform.com", portNumber);
 
-            var ipandport = client.Client.RemoteEndPoint.ToString();
-            var ip = ipandport.Replace(ipandport.Substring(ipandport.IndexOf(':')), "");
-
-            var endpointDiscovered = new IPEndPoint(IPAddress.Parse(ip), portNumber);
+            var ipAndPort = client.Client.RemoteEndPoint.ToString();
+            var ip = ipAndPort.Substring(0, ipAndPort.LastIndexOf(':'));
+            IPAddress ipAddress;
+            if (!IPAddress.TryParse(ip, out ipAddress))
+            {
+                // Log error or handle the case where IP address is not valid
+                throw new InvalidOperationException("The IP address format is invalid.");
+            }
+            var endpointDiscovered = new IPEndPoint(ipAddress, portNumber);
 
             // Include the external client as a NodeServerEndpoint.
             connectionManagerSettings.Bind.Add(new NodeServerEndpoint(endpointDiscovered, isWhiteListed));


### PR DESCRIPTION
This PR will upgrade the blockcore project to dotnet 8
1 fix was required for the test case Validate_AllowClientConnection_State
There are no library updates, however there is a need to upgrade all vulenrable and deprecated libraries.

I think due to the number of changes required for updating each library, it's worth creating seperate PR's for those