### PR TITLE
Upgrade LiteDB@5.0.15

### DIFF
--- a/src/Blockcore/Blockcore.csproj
+++ b/src/Blockcore/Blockcore.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
     <PackageReference Include="DBreeze" Version="1.115.2023.1103" />
-    <PackageReference Include="LiteDB" Version="5.0.14" />
+    <PackageReference Include="LiteDB" Version="5.0.15" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.8" />

--- a/src/Blockcore/Blockcore.csproj
+++ b/src/Blockcore/Blockcore.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
     <PackageReference Include="DBreeze" Version="1.115.2023.1103" />
-    <PackageReference Include="LiteDB" Version="4.1.4" />
+    <PackageReference Include="LiteDB" Version="5.0.14" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.8" />

--- a/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexRepository.cs
+++ b/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexRepository.cs
@@ -58,7 +58,8 @@ namespace Blockcore.Features.BlockStore.AddressIndexing
             this.SaveAllItems();
 
             // Need to specify index name explicitly so that it gets used for the query.
-            IEnumerable<AddressIndexerData> affectedAddresses = this.addressIndexerDataCollection.Find(Query.GT("BalanceChangedHeightIndex", height));
+            // Query to find documents where any BalanceChangedHeight in the BalanceChanges array is greater than 'height'
+            IEnumerable<AddressIndexerData> affectedAddresses = this.addressIndexerDataCollection.Find(Query.GT("$.BalanceChanges[*].BalanceChangedHeight ANY", height)).ToList();
 
             // Per LiteDb documentation:
             // "Returning an IEnumerable your code still connected to datafile.

--- a/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexRepository.cs
+++ b/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexRepository.cs
@@ -13,7 +13,7 @@ namespace Blockcore.Features.BlockStore.AddressIndexing
     {
         private const string DbAddressDataKey = "AddrData";
 
-        private readonly LiteCollection<AddressIndexerData> addressIndexerDataCollection;
+        private readonly ILiteCollection<AddressIndexerData> addressIndexerDataCollection;
 
         private readonly ILogger logger;
 

--- a/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -20,7 +20,6 @@ using Blockcore.NBitcoin;
 using Blockcore.Networks;
 using Blockcore.Utilities;
 using LiteDB;
-using FileMode = LiteDB.FileMode;
 using Microsoft.Extensions.Logging;
 using Script = Blockcore.Consensus.ScriptInfo.Script;
 
@@ -86,7 +85,7 @@ namespace Blockcore.Features.BlockStore.AddressIndexing
 
         private LiteDatabase db;
 
-        private LiteCollection<AddressIndexerTipData> tipDataStore;
+        private ILiteCollection<AddressIndexerTipData> tipDataStore;
 
         /// <summary>A mapping between addresses and their balance changes.</summary>
         /// <remarks>All access should be protected by <see cref="lockObject"/>.</remarks>
@@ -179,8 +178,8 @@ namespace Blockcore.Features.BlockStore.AddressIndexing
 
             string dbPath = Path.Combine(this.dataFolder.RootPath, AddressIndexerDatabaseFilename);
 
-            FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? FileMode.Exclusive : FileMode.Shared;
-            this.db = new LiteDatabase(new ConnectionString() { Filename = dbPath, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            this.db = new LiteDatabase(new ConnectionString() { Filename = dbPath, Connection = connectionType });
 
             this.addressIndexRepository = new AddressIndexRepository(this.db, this.loggerFactory);
 

--- a/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexerOutpointsRepository.cs
+++ b/src/Features/Blockcore.Features.BlockStore/AddressIndexing/AddressIndexerOutpointsRepository.cs
@@ -17,11 +17,11 @@ namespace Blockcore.Features.BlockStore.AddressIndexing
 
         /// <summary>Represents the output collection.</summary>
         /// <remarks>Should be protected by <see cref="LockObject"/></remarks>
-        private readonly LiteCollection<OutPointData> addressIndexerOutPointData;
+        private readonly ILiteCollection<OutPointData> addressIndexerOutPointData;
 
         /// <summary>Represents the rewind data collection.</summary>
         /// <remarks>Should be protected by <see cref="LockObject"/></remarks>
-        private readonly LiteCollection<AddressIndexerRewindData> addressIndexerRewindData;
+        private readonly ILiteCollection<AddressIndexerRewindData> addressIndexerRewindData;
 
         private readonly ILogger logger;
 
@@ -119,7 +119,9 @@ namespace Blockcore.Features.BlockStore.AddressIndexing
         public void PurgeOldRewindData(int height)
         {
             // Delete all in one go based on query. This is more optimal than query, iterate and delete individual records.
-            int purgedCount = this.addressIndexerRewindData.Delete(x => x.BlockHeight < height);
+            //BsonExpression predicate = Query.LT("BlockHeight", height);
+           // int purgedCount = this.addressIndexerRewindData.DeleteMany(predicate);
+           int purgedCount = this.addressIndexerRewindData.DeleteMany(x => x.BlockHeight < height);
 
             this.logger.LogInformation("Purged {0} rewind data items.", purgedCount);
         }

--- a/src/Tests/Blockcore.Features.BlockStore.Tests/AddressIndexerOutpointsRepositoryTests.cs
+++ b/src/Tests/Blockcore.Features.BlockStore.Tests/AddressIndexerOutpointsRepositoryTests.cs
@@ -21,8 +21,8 @@ namespace Blockcore.Features.BlockStore.Tests
 
         public AddressIndexerOutpointsRepositoryTests()
         {
-            LiteDB.FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? LiteDB.FileMode.Exclusive : LiteDB.FileMode.Shared;
-            var db = new LiteDatabase(new ConnectionString() { Filename = this.RandomString(20) + ".db", Upgrade = true, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            var db = new LiteDatabase(new ConnectionString() { Filename = this.RandomString(20) + ".db", Upgrade = true, Connection = connectionType });
 
             this.repository = new AddressIndexerOutpointsRepository(db, new ExtendedLoggerFactory(), this.maxItems);
         }

--- a/src/Tests/Blockcore.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Tests/Blockcore.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -181,8 +181,8 @@ namespace Blockcore.Features.BlockStore.Tests
             var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
             string dbPath = Path.Combine(dataFolder.RootPath, CollectionName);
 
-            LiteDB.FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? LiteDB.FileMode.Exclusive : LiteDB.FileMode.Shared;
-            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Connection = connectionType });
             var cache = new AddressIndexerOutpointsRepository(database, new ExtendedLoggerFactory());
 
             var outPoint = new OutPoint(uint256.Parse("0000af9ab2c8660481328d0444cf167dfd31f24ca2dbba8e5e963a2434cffa93"), 0);
@@ -204,8 +204,8 @@ namespace Blockcore.Features.BlockStore.Tests
             var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
             string dbPath = Path.Combine(dataFolder.RootPath, CollectionName);
 
-            LiteDB.FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? LiteDB.FileMode.Exclusive : LiteDB.FileMode.Shared;
-            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Connection = connectionType });
             var cache = new AddressIndexerOutpointsRepository(database, new ExtendedLoggerFactory());
 
             Assert.False(cache.TryGetOutPointData(new OutPoint(uint256.Parse("0000af9ab2c8660481328d0444cf167dfd31f24ca2dbba8e5e963a2434cffa93"), 1), out OutPointData retrieved));
@@ -219,8 +219,8 @@ namespace Blockcore.Features.BlockStore.Tests
             var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
             string dbPath = Path.Combine(dataFolder.RootPath, CollectionName);
 
-            LiteDB.FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? LiteDB.FileMode.Exclusive : LiteDB.FileMode.Shared;
-            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Connection = connectionType });
             var cache = new AddressIndexerOutpointsRepository(database, new ExtendedLoggerFactory(), 2);
 
             Assert.Equal(0, cache.Count);
@@ -270,8 +270,8 @@ namespace Blockcore.Features.BlockStore.Tests
             var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
             string dbPath = Path.Combine(dataFolder.RootPath, CollectionName);
 
-            LiteDB.FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? LiteDB.FileMode.Exclusive : LiteDB.FileMode.Shared;
-            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Connection = connectionType });
             var cache = new AddressIndexRepository(database, new ExtendedLoggerFactory());
 
             string address = "xyz";
@@ -299,8 +299,8 @@ namespace Blockcore.Features.BlockStore.Tests
             var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
             string dbPath = Path.Combine(dataFolder.RootPath, CollectionName);
 
-            LiteDB.FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? LiteDB.FileMode.Exclusive : LiteDB.FileMode.Shared;
-            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Connection = connectionType });
             var cache = new AddressIndexRepository(database, new ExtendedLoggerFactory());
 
             AddressIndexerData retrieved = cache.GetOrCreateAddress("xyz");
@@ -318,8 +318,8 @@ namespace Blockcore.Features.BlockStore.Tests
             var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
             string dbPath = Path.Combine(dataFolder.RootPath, CollectionName);
 
-            LiteDB.FileMode fileMode = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? LiteDB.FileMode.Exclusive : LiteDB.FileMode.Shared;
-            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Mode = fileMode });
+            ConnectionType connectionType = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ConnectionType.Direct : ConnectionType.Shared;
+            var database = new LiteDatabase(new ConnectionString() { Filename = dbPath, Upgrade = true, Connection = connectionType });
             var cache = new AddressIndexRepository(database, new ExtendedLoggerFactory(), 4);
 
             // Recall, each index entry counts as 1 and each balance change associated with it is an additional 1.


### PR DESCRIPTION
@dangershony @sondreb  

I am unable to understand why the Fork is not be rewinded, and why Block 10 still appears in the fork.

Please review the changes, and see if this is something we can fix, or if we leave LiteDB at the current version.
Please note that there are vulenrabilities reported on LiteDB, and this version i've picked is the first version that seems the most stable (most tests pass on BlocCore), when compared to any later version.  There are bugs with Transactions in LiteDB which must be resolved prior to any further upgrades of the library.

```
Failed Tests:

 CanIndexAddresses
   Source: AddressIndexerTests.cs line 72
   Duration: 6.2 sec

  Message: 
Assert.Equal() Failure: Values differ
Expected: 70000
Actual:   60000

  Stack Trace: 
AddressIndexerTests.CanIndexAddresses() line 159
RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

```
